### PR TITLE
fix: canvas dedup, template IDs, doc viewer modal, hint editing

### DIFF
--- a/client/src/components/Chat/ChatDrawer.tsx
+++ b/client/src/components/Chat/ChatDrawer.tsx
@@ -20,6 +20,7 @@ interface ChatDrawerProps {
   suggestions?: string[];
   minRole?: UserRoles;
   onToolResult?: (toolName: string, result: string) => void;
+  onDocRefClick?: (enrichedFileId: string, page?: number) => void;
   initialConversationId?: string;
 }
 
@@ -33,6 +34,7 @@ const ChatDrawer = ({
   suggestions,
   minRole = UserRoles.User,
   onToolResult,
+  onDocRefClick,
   initialConversationId,
 }: ChatDrawerProps) => {
   const [isDesktop] = useMediaQuery("(min-width: 768px)");
@@ -117,6 +119,7 @@ const ChatDrawer = ({
             height="100%"
             minRole={minRole}
             onToolResult={onToolResult}
+            onDocRefClick={onDocRefClick}
             initialConversationId={initialConversationId}
           />
         </Box>

--- a/client/src/components/Chat/ChatPage.tsx
+++ b/client/src/components/Chat/ChatPage.tsx
@@ -73,9 +73,10 @@ interface MessageBubbleProps {
   rateMessage: (messageId: string, rating: "up" | "down" | null, reasons?: string[], comment?: string) => void;
   isLastAssistant?: boolean;
   onRegenerate?: () => void;
+  onDocRefClick?: (enrichedFileId: string, page?: number) => void;
 }
 
-const MessageBubble = React.memo(({ msg, onShowSources, rateMessage, isLastAssistant, onRegenerate }: MessageBubbleProps) => {
+const MessageBubble = React.memo(({ msg, onShowSources, rateMessage, isLastAssistant, onRegenerate, onDocRefClick }: MessageBubbleProps) => {
   if (msg.role === "user") {
     return (
       <Box
@@ -130,7 +131,7 @@ const MessageBubble = React.memo(({ msg, onShowSources, rateMessage, isLastAssis
           </HStack>
         ) : (
           <>
-            <MarkdownContent content={msg.content} />
+            <MarkdownContent content={msg.content} onDocRefClick={onDocRefClick} />
             {msg.isStreaming && (
               <Box
                 display="inline-block"
@@ -311,6 +312,7 @@ interface ChatPageProps {
   height?: string;                 // override container height, default: calc(100vh - navbarHeight)
   minRole?: UserRoles;             // minimum role required to access chat, default: ProjectManager
   onToolResult?: (toolName: string, result: string) => void;
+  onDocRefClick?: (enrichedFileId: string, page?: number) => void;
 }
 
 const ChatPage = ({
@@ -323,6 +325,7 @@ const ChatPage = ({
   height,
   minRole = UserRoles.ProjectManager,
   onToolResult,
+  onDocRefClick,
 }: ChatPageProps) => {
   const router = useRouter();
   const [messages, setMessages] = React.useState<ChatMessage[]>([]);
@@ -1021,6 +1024,7 @@ const ChatPage = ({
                           rateMessage={rateMessage}
                           isLastAssistant={isLastAssistant}
                           onRegenerate={regenerateLastMessage}
+                          onDocRefClick={onDocRefClick}
                         />
                       </Box>
                     );

--- a/client/src/components/Chat/MarkdownContent.tsx
+++ b/client/src/components/Chat/MarkdownContent.tsx
@@ -5,7 +5,12 @@ import remarkGfm from "remark-gfm";
 import { CopyableTable } from "./CopyableTable";
 import { localStorageTokenKey } from "../../contexts/Auth";
 
-const MarkdownContent = ({ content }: { content: string }) => (
+interface MarkdownContentProps {
+  content: string;
+  onDocRefClick?: (enrichedFileId: string, page?: number) => void;
+}
+
+const MarkdownContent = ({ content, onDocRefClick }: MarkdownContentProps) => (
   <ReactMarkdown
     remarkPlugins={[remarkGfm]}
     components={{
@@ -49,8 +54,29 @@ const MarkdownContent = ({ content }: { content: string }) => (
         <Box borderLeft="3px solid" borderColor="blue.300" pl={3} py={0.5} my={2} color="gray.600">{children}</Box>
       ),
       a: ({ href, children }) => {
-        // For enriched-file links, append the current JWT at render time so
-        // links don't expire when the token baked into an old conversation ages out.
+        // For enriched-file links, open in the document viewer modal if a handler is provided.
+        if (href?.includes("/api/enriched-files/") && onDocRefClick) {
+          const match = href.match(/\/api\/enriched-files\/([a-f0-9]+)/);
+          const pageMatch = href.match(/#page=(\d+)/);
+          if (match) {
+            const fileId = match[1];
+            const page = pageMatch ? parseInt(pageMatch[1], 10) : undefined;
+            return (
+              <Box
+                as="span"
+                color="blue.600"
+                textDecoration="underline"
+                cursor="pointer"
+                _hover={{ color: "blue.800" }}
+                onClick={(e: React.MouseEvent) => { e.preventDefault(); onDocRefClick(fileId, page); }}
+              >
+                {children}
+              </Box>
+            );
+          }
+        }
+        // For enriched-file links without a handler, append the current JWT at render time
+        // so links don't expire when the token baked into an old conversation ages out.
         let resolvedHref = href;
         if (href?.includes("/api/enriched-files/") && typeof window !== "undefined") {
           const token = localStorage.getItem(localStorageTokenKey);

--- a/client/src/components/Common/DocumentViewerModal.tsx
+++ b/client/src/components/Common/DocumentViewerModal.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  Box,
+  Button,
+  Flex,
+  Text,
+} from "@chakra-ui/react";
+import { FiExternalLink } from "react-icons/fi";
+import dynamic from "next/dynamic";
+import { localStorageTokenKey } from "../../contexts/Auth";
+
+const PdfViewer = dynamic(
+  () => import("../TenderPricing/PdfViewer"),
+  { ssr: false, loading: () => <Flex h="100%" align="center" justify="center"><Text color="gray.400">Loading viewer...</Text></Flex> }
+);
+
+export interface DocumentViewerFile {
+  enrichedFileId: string;
+  fileName?: string;
+  mimetype?: string;
+  page?: number;
+}
+
+interface DocumentViewerModalProps {
+  file: DocumentViewerFile | null;
+  onClose: () => void;
+}
+
+function buildStreamUrl(fileId: string): string {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem(localStorageTokenKey) : null;
+  const params = new URLSearchParams();
+  if (token) params.set("token", token);
+  params.set("stream", "1");
+  return `/api/enriched-files/${fileId}?${params.toString()}`;
+}
+
+function buildDownloadUrl(fileId: string): string {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem(localStorageTokenKey) : null;
+  const params = new URLSearchParams();
+  if (token) params.set("token", token);
+  const qs = params.toString();
+  return `/api/enriched-files/${fileId}${qs ? `?${qs}` : ""}`;
+}
+
+function isPdf(mimetype?: string): boolean {
+  return mimetype === "application/pdf" || mimetype === undefined;
+}
+
+function isImage(mimetype?: string): boolean {
+  return !!mimetype?.startsWith("image/");
+}
+
+const DocumentViewerModal: React.FC<DocumentViewerModalProps> = ({ file, onClose }) => {
+  if (!file) return null;
+
+  const title = file.fileName ?? "Document";
+
+  return (
+    <Modal isOpen={!!file} onClose={onClose} size="6xl" isCentered>
+      <ModalOverlay bg="blackAlpha.700" />
+      <ModalContent h="85vh" maxH="85vh" display="flex" flexDir="column">
+        <ModalHeader fontSize="md" py={3} pr={12} borderBottom="1px solid" borderColor="gray.200">
+          {title}
+          {file.page && <Text as="span" color="gray.500" fontWeight="normal" ml={2}>p. {file.page}</Text>}
+        </ModalHeader>
+        <ModalCloseButton />
+        <ModalBody flex={1} p={0} overflow="hidden">
+          {isPdf(file.mimetype) ? (
+            <PdfViewer
+              url={buildStreamUrl(file.enrichedFileId)}
+              fileName={title}
+              initialPage={file.page}
+            />
+          ) : isImage(file.mimetype) ? (
+            <Flex h="100%" align="center" justify="center" p={4} overflow="auto">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={buildDownloadUrl(file.enrichedFileId)}
+                alt={title}
+                style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain" }}
+              />
+            </Flex>
+          ) : (
+            <Flex h="100%" direction="column" align="center" justify="center" gap={4}>
+              <Text color="gray.500">Preview not available for this file type</Text>
+              <Button
+                as="a"
+                href={buildDownloadUrl(file.enrichedFileId)}
+                target="_blank"
+                rel="noopener noreferrer"
+                leftIcon={<FiExternalLink />}
+                colorScheme="blue"
+                variant="outline"
+                size="sm"
+              >
+                Open in new tab
+              </Button>
+            </Flex>
+          )}
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default DocumentViewerModal;

--- a/client/src/components/pages/developer/CalculatorCanvas/InspectPanel.tsx
+++ b/client/src/components/pages/developer/CalculatorCanvas/InspectPanel.tsx
@@ -181,7 +181,7 @@ const ParamEdit: React.FC<{
 }> = ({ doc, nodeId, onUpdateDoc }) => {
   const param = doc.parameterDefs.find((p) => p.id === nodeId)!;
 
-  const saveField = (updates: { label?: string; suffix?: string | undefined; defaultValue?: number }) => {
+  const saveField = (updates: { label?: string; suffix?: string | undefined; defaultValue?: number; hint?: string | undefined }) => {
     // defaultValue is now stored directly on the ParameterDef
     onUpdateDoc({ ...doc, parameterDefs: doc.parameterDefs.map((p) => p.id === nodeId ? { ...p, ...updates } : p) });
   };
@@ -207,6 +207,8 @@ const ParamEdit: React.FC<{
         onBlur={(v) => saveField({ suffix: v || undefined })} />
       <EditField label="Default Value" value={String(param.defaultValue)}
         type="number" mono onBlur={(v) => saveField({ defaultValue: parseFloat(v) || 0 })} />
+      <EditField label="Hint" value={param.hint ?? ""} placeholder="Guidance for estimators"
+        onBlur={(v) => saveField({ hint: v || undefined })} />
     </>
   );
 };
@@ -585,6 +587,9 @@ const ControllerEdit: React.FC<{
           )}
         </Box>
       )}
+
+      <EditField label="Hint" value={ctrl.hint ?? ""} placeholder="Guidance for estimators"
+        onBlur={(v) => updateCtrl({ hint: v || undefined })} />
     </>
   );
 };
@@ -721,6 +726,11 @@ const TableLabelEdit: React.FC<{
       <EditField label="Label" value={tableDef.label} onBlur={saveLabel} />
       <EditField label="Row Label" value={tableDef.rowLabel} placeholder="e.g. Role, Equipment, Item"
         onBlur={saveRowLabel} />
+      <EditField label="Hint" value={tableDef.hint ?? ""} placeholder="Guidance for estimators"
+        onBlur={(v) => onUpdateDoc({
+          ...doc,
+          tableDefs: doc.tableDefs.map((t) => t.id === tId ? { ...t, hint: v || undefined } : t),
+        })} />
     </>
   );
 };

--- a/client/src/components/pages/developer/CalculatorCanvas/canvasStorage.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/canvasStorage.ts
@@ -354,14 +354,25 @@ export function fragmentToDoc(f: RateBuildupTemplateFullSnippetFragment): Canvas
     try { controllerDefs = JSON.parse(f.controllerDefs); } catch { /* ignore */ }
   }
 
+  // Deduplicate defs by ID — protects against duplicate entries that may have been
+  // saved when the canvas had a bug where content edits didn't visually reflect.
+  const dedup = <T extends { id: string }>(arr: T[]): T[] => {
+    const seen = new Set<string>();
+    return arr.filter((item) => {
+      if (seen.has(item.id)) return false;
+      seen.add(item.id);
+      return true;
+    });
+  };
+
   return {
     id: f._id,
     label: f.label,
     defaultUnit: f.defaultUnit ?? "unit",
-    parameterDefs: (f.parameterDefs ?? []) as CanvasParameterDef[],
-    tableDefs: (f.tableDefs ?? []) as CanvasTableDef[],
-    formulaSteps: (f.formulaSteps ?? []) as CanvasFormulaStep[],
-    breakdownDefs: (f.breakdownDefs ?? []) as CanvasBreakdownDef[],
+    parameterDefs: dedup((f.parameterDefs ?? []) as CanvasParameterDef[]),
+    tableDefs: dedup((f.tableDefs ?? []) as CanvasTableDef[]),
+    formulaSteps: dedup((f.formulaSteps ?? []) as CanvasFormulaStep[]),
+    breakdownDefs: dedup((f.breakdownDefs ?? []) as CanvasBreakdownDef[]),
     intermediateDefs: (f.intermediateDefs ?? []) as IntermediateDef[],
     specialPositions,
     groupDefs,

--- a/client/src/components/pages/developer/CalculatorCanvas/canvasStorage.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/canvasStorage.ts
@@ -539,12 +539,19 @@ export function useCanvasDocuments() {
 
   const createDocument = useCallback(async (): Promise<string> => {
     const doc = blankDocument();
-    setDocs((prev) => {
-      scheduleSave(doc);
-      return [...prev, doc];
+    // Save immediately (not debounced) so we get the real server ID back.
+    const result = await client.mutate({
+      mutation: SaveRateBuildupTemplateDocument,
+      variables: docToVariables(doc, idRemap.current),
     });
-    return doc.id;
-  }, [scheduleSave]);
+    const saved = result.data?.saveRateBuildupTemplate;
+    const realId = saved?._id ?? doc.id;
+    if (realId !== doc.id) {
+      idRemap.current.set(doc.id, realId);
+    }
+    setDocs((prev) => [...prev, doc]);
+    return realId;
+  }, [client]);
 
   const forkDocument = useCallback(
     async (sourceId: string): Promise<string | null> => {
@@ -555,13 +562,20 @@ export function useCanvasDocuments() {
         id: `new_${Date.now()}`,
         label: `${source.label} (copy)`,
       };
-      setDocs((prev) => {
-        scheduleSave(forked);
-        return [...prev, forked];
+      // Save immediately so we get the real server ID back.
+      const result = await client.mutate({
+        mutation: SaveRateBuildupTemplateDocument,
+        variables: docToVariables(forked, idRemap.current),
       });
-      return forked.id;
+      const saved = result.data?.saveRateBuildupTemplate;
+      const realId = saved?._id ?? forked.id;
+      if (realId !== forked.id) {
+        idRemap.current.set(forked.id, realId);
+      }
+      setDocs((prev) => [...prev, forked]);
+      return realId;
     },
-    [docs, scheduleSave]
+    [docs, client]
   );
 
   const deleteDocument = useCallback(

--- a/client/src/pages/tender/[id]/index.tsx
+++ b/client/src/pages/tender/[id]/index.tsx
@@ -29,6 +29,7 @@ import { UserRoles } from "../../../generated/graphql";
 import { navbarHeight } from "../../../constants/styles";
 import { localStorageTokenKey } from "../../../contexts/Auth";
 import ChatDrawer from "../../../components/Chat/ChatDrawer";
+import DocumentViewerModal, { DocumentViewerFile } from "../../../components/Common/DocumentViewerModal";
 import TenderMobileLayout from "../../../components/Tender/TenderMobileLayout";
 
 // Lazy-load PdfViewer to avoid SSR issues with react-pdf
@@ -278,6 +279,7 @@ const TenderDetailPage = () => {
   const [panelWidthPx, setPanelWidthPx] = useState<number | null>(null);
   const [selectedFile, setSelectedFile] = useState<TenderFileItem | null>(null);
   const [selectedFilePage, setSelectedFilePage] = useState<number>(1);
+  const [docViewerFile, setDocViewerFile] = useState<DocumentViewerFile | null>(null);
   const isDraggingPanel = useRef(false);
   const [isMobile, setIsMobile] = useState(false);
   useEffect(() => {
@@ -420,6 +422,16 @@ const TenderDetailPage = () => {
     handleOpenFile(file, page);
   }, [tender?.files, handleOpenFile]);
 
+  const handleChatDocRefClick = useCallback((enrichedFileId: string, page?: number) => {
+    const file = tender?.files.find((f) => f._id === enrichedFileId);
+    setDocViewerFile({
+      enrichedFileId,
+      fileName: file?.file?.description ?? undefined,
+      mimetype: file?.file?.mimetype ?? undefined,
+      page,
+    });
+  }, [tender?.files]);
+
   const panelWidth =
     panelState === "fullscreen"
       ? "100%"
@@ -538,7 +550,7 @@ const TenderDetailPage = () => {
                 bottom={0}
                 w="5px"
                 cursor="col-resize"
-                zIndex={10}
+                zIndex={2}
                 _hover={{ bg: "blue.200" }}
                 transition="background 0.15s"
                 onMouseDown={(e) => {
@@ -709,6 +721,13 @@ const TenderDetailPage = () => {
               refetchTender();
             }
           }}
+          onDocRefClick={handleChatDocRefClick}
+        />
+
+        {/* ── Document viewer modal (for chat references) ─────────────── */}
+        <DocumentViewerModal
+          file={docViewerFile}
+          onClose={() => setDocViewerFile(null)}
         />
       </Flex>
       )}


### PR DESCRIPTION
## Summary
- **Deduplicate canvas defs on load** — fixes duplicate rate tables caused by earlier canvas update bug
- **New template links to real server ID** — `/pricing/rate-builder/<real-id>` instead of `new_<timestamp>`
- **Document viewer modal** — chat bot citations open inline PDF viewer instead of new tab
- **Hint editing in InspectPanel** — params, tables, and controllers can now have estimator guidance hints

## Test plan
- [ ] Open the affected production template — verify duplicate tables are gone
- [ ] Create a new template from `/pricing` — verify URL uses real MongoDB ID
- [ ] Open tender chat, click a document citation — verify PDF modal opens at cited page
- [ ] Select a parameter/table/controller in canvas — verify "Hint" field appears in InspectPanel

🤖 Generated with [Claude Code](https://claude.com/claude-code)