### PR TITLE
fix: duplicate table rendering in Hand Pour group

### DIFF
--- a/client/src/components/pages/developer/CalculatorCanvas/canvasStorage.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/canvasStorage.ts
@@ -346,6 +346,8 @@ export function fragmentToDoc(f: RateBuildupTemplateFullSnippetFragment): Canvas
   } else if (typeof f.groupDefs === "string") {
     try { groupDefs = JSON.parse(f.groupDefs); } catch { /* ignore */ }
   }
+  // Deduplicate memberIds within each group
+  groupDefs = groupDefs.map((g) => ({ ...g, memberIds: [...new Set(g.memberIds)] }));
 
   let controllerDefs: ControllerDef[] = [];
   if (Array.isArray(f.controllerDefs)) {


### PR DESCRIPTION
## Summary
- Deduplicate group `memberIds` on document load — `hand_pour_equipmentRatePerHr` was listed twice in the Hand Pour group, causing two identical tables to render

## Test plan
- [ ] Open Concrete Pour > Hand Pour template — verify only one "Hand Pour Equipment" table appears
- [ ] Verify the table has its correct rows populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)