### PR TITLE
feat: chat markdown rendering + line break support

### DIFF
--- a/client/src/components/Chat/ChatPage.tsx
+++ b/client/src/components/Chat/ChatPage.tsx
@@ -87,7 +87,7 @@ const MessageBubble = React.memo(({ msg, onShowSources, rateMessage, isLastAssis
         borderRadius="lg"
         borderBottomRightRadius="sm"
       >
-        <Text fontSize="sm" lineHeight="1.6">{msg.content}</Text>
+        <Text fontSize="sm" lineHeight="1.6" whiteSpace="pre-wrap">{msg.content}</Text>
       </Box>
     );
   }

--- a/client/src/components/Chat/ChatPage.tsx
+++ b/client/src/components/Chat/ChatPage.tsx
@@ -87,7 +87,9 @@ const MessageBubble = React.memo(({ msg, onShowSources, rateMessage, isLastAssis
         borderRadius="lg"
         borderBottomRightRadius="sm"
       >
-        <Text fontSize="sm" lineHeight="1.6" whiteSpace="pre-wrap">{msg.content}</Text>
+        <Box sx={{ "& p, & li, & code, & td, & th": { color: "white" }, "& a": { color: "blue.200" }, "& hr": { borderColor: "whiteAlpha.400" }, "& blockquote": { borderColor: "blue.200", color: "whiteAlpha.800" }, "& table": { borderColor: "whiteAlpha.300" }, "& thead": { bg: "whiteAlpha.100" }, "& code:not([class])": { bg: "whiteAlpha.200" }, "& pre code": { bg: "transparent" } }}>
+          <MarkdownContent content={msg.content} />
+        </Box>
       </Box>
     );
   }

--- a/client/src/components/Chat/MarkdownContent.tsx
+++ b/client/src/components/Chat/MarkdownContent.tsx
@@ -2,6 +2,11 @@ import React from "react";
 import { Box, Code, Text } from "@chakra-ui/react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+// Convert single newlines to markdown hard breaks (two trailing spaces + newline)
+// so user-typed Shift+Enter line breaks render correctly.
+function preserveLineBreaks(text: string): string {
+  return text.replace(/(?<! {2})\n/g, "  \n");
+}
 import { CopyableTable } from "./CopyableTable";
 import { localStorageTokenKey } from "../../contexts/Auth";
 
@@ -102,7 +107,7 @@ const MarkdownContent = ({ content, onDocRefClick }: MarkdownContentProps) => (
       },
     }}
   >
-    {content}
+    {preserveLineBreaks(content)}
   </ReactMarkdown>
 );
 


### PR DESCRIPTION
## Summary
- User messages now render with full markdown formatting (bold, lists, code blocks, tables)
- Shift+Enter newlines display correctly in both user and assistant messages
- Text colors adjusted for white-on-blue user message bubbles

## Test plan
- [ ] Send a message with Shift+Enter line breaks — verify they render
- [ ] Paste markdown with lists/bold/code — verify it formats in the user bubble
- [ ] Verify assistant messages still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)