### PR TITLE
feat: tender review + audit trail + line item kanban

### DIFF
--- a/client/src/components/Tender/TenderMobileLayout.tsx
+++ b/client/src/components/Tender/TenderMobileLayout.tsx
@@ -8,25 +8,27 @@ import {
   Spinner,
   Text,
 } from "@chakra-ui/react";
-import { FiChevronLeft, FiFileText, FiList, FiMessageSquare, FiAlignLeft } from "react-icons/fi";
+import { FiChevronLeft, FiClock, FiFileText, FiList, FiMessageSquare, FiAlignLeft } from "react-icons/fi";
 import { useRouter } from "next/router";
 import TenderMobilePricingTab from "./TenderMobilePricingTab";
 import TenderMobileDocumentsTab from "./TenderMobileDocumentsTab";
 import TenderSummaryTab from "./TenderSummaryTab";
 import TenderNotesTab from "./TenderNotesTab";
+import TenderMobileReviewTab from "./TenderMobileReviewTab";
 import { TenderDetail, tenderStatusColor } from "./types";
 import { TenderPricingSheet } from "../TenderPricing/types";
 import { navbarHeight } from "../../constants/styles";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type MobileTab = "pricing" | "documents" | "notes" | "summary";
+type MobileTab = "pricing" | "documents" | "notes" | "summary" | "review";
 
 const TABS: { key: MobileTab; label: string; icon: React.ReactElement }[] = [
   { key: "pricing", label: "Pricing", icon: <FiList size={18} /> },
   { key: "documents", label: "Documents", icon: <FiFileText size={18} /> },
   { key: "notes", label: "Notes", icon: <FiMessageSquare size={18} /> },
   { key: "summary", label: "Summary", icon: <FiAlignLeft size={18} /> },
+  { key: "review", label: "Review", icon: <FiClock size={18} /> },
 ];
 
 const TAB_BAR_HEIGHT = "56px";
@@ -120,6 +122,9 @@ const TenderMobileLayout: React.FC<TenderMobileLayoutProps> = ({
           <Box h="100%" overflowY="auto" px={4} py={3}>
             <TenderSummaryTab tender={tender} onUpdated={onRefetch} />
           </Box>
+        )}
+        {activeTab === "review" && (
+          <TenderMobileReviewTab tenderId={tenderId} />
         )}
       </Box>
 

--- a/client/src/components/Tender/TenderMobilePricingTab.tsx
+++ b/client/src/components/Tender/TenderMobilePricingTab.tsx
@@ -2,6 +2,8 @@
 import React, { useCallback, useRef, useState } from "react";
 import {
   Box,
+  Button,
+  ButtonGroup,
   Drawer,
   DrawerBody,
   DrawerContent,
@@ -19,6 +21,7 @@ import { FiChevronLeft, FiDownload } from "react-icons/fi";
 import dynamic from "next/dynamic";
 import ClientOnly from "../Common/ClientOnly";
 import LineItemDetail from "../TenderPricing/LineItemDetail";
+import PricingBoard from "../TenderPricing/PricingBoard";
 import { TenderPricingSheet, TenderPricingRow, TenderPricingRowType } from "../TenderPricing/types";
 import { TenderFileItem } from "./types";
 import { localStorageTokenKey } from "../../contexts/Auth";
@@ -174,6 +177,7 @@ const TenderMobilePricingTab: React.FC<TenderMobilePricingTabProps> = ({
   onSheetUpdate,
   tenderFiles,
 }) => {
+  const [viewMode, setViewMode] = useState<"list" | "board">("list");
   const [selectedRow, setSelectedRow] = useState<TenderPricingRow | null>(null);
   const [viewingFile, setViewingFile] = useState<{ fileId: string; fileName: string; page?: number } | null>(null);
   const [updateRow] = useMutation(UPDATE_ROW);
@@ -296,17 +300,49 @@ const TenderMobilePricingTab: React.FC<TenderMobilePricingTabProps> = ({
         </Text>
       </Flex>
 
-      {/* Row list */}
-      <Box flex={1} overflowY="auto">
-        {sheet.rows.map((row) => (
-          <RowItem
-            key={row._id}
-            row={row}
-            defaultMarkupPct={sheet.defaultMarkupPct}
-            onSelect={setSelectedRow}
+      {/* View toggle */}
+      <Flex px={3} py={2} flexShrink={0}>
+        <ButtonGroup size="xs" isAttached variant="outline">
+          <Button
+            onClick={() => setViewMode("list")}
+            colorScheme={viewMode === "list" ? "blue" : "gray"}
+            variant={viewMode === "list" ? "solid" : "outline"}
+          >
+            List
+          </Button>
+          <Button
+            onClick={() => setViewMode("board")}
+            colorScheme={viewMode === "board" ? "blue" : "gray"}
+            variant={viewMode === "board" ? "solid" : "outline"}
+          >
+            Board
+          </Button>
+        </ButtonGroup>
+      </Flex>
+
+      {/* Row list / board */}
+      {viewMode === "board" ? (
+        <Box flex={1} overflow="hidden">
+          <PricingBoard
+            sheet={sheet}
+            tenderId={tenderId}
+            onUpdate={onSheetUpdate}
+            onUpdateRow={handleUpdateRow}
+            tenderFiles={tenderFiles}
           />
-        ))}
-      </Box>
+        </Box>
+      ) : (
+        <Box flex={1} overflowY="auto">
+          {sheet.rows.map((row) => (
+            <RowItem
+              key={row._id}
+              row={row}
+              defaultMarkupPct={sheet.defaultMarkupPct}
+              onSelect={setSelectedRow}
+            />
+          ))}
+        </Box>
+      )}
 
       {/* Line item drawer */}
       <Drawer

--- a/client/src/components/Tender/TenderMobilePricingTab.tsx
+++ b/client/src/components/Tender/TenderMobilePricingTab.tsx
@@ -56,6 +56,7 @@ const ROW_FIELDS = `
   rateBuildupSnapshot
   extraUnitPrice
   extraUnitPriceMemo
+  status
   docRefs {
     _id
     enrichedFileId

--- a/client/src/components/Tender/TenderMobilePricingTab.tsx
+++ b/client/src/components/Tender/TenderMobilePricingTab.tsx
@@ -52,8 +52,6 @@ const ROW_FIELDS = `
   unit
   unitPrice
   notes
-  calculatorType
-  calculatorInputsJson
   markupOverride
   rateBuildupSnapshot
   extraUnitPrice

--- a/client/src/components/Tender/TenderMobileReviewTab.tsx
+++ b/client/src/components/Tender/TenderMobileReviewTab.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Box } from "@chakra-ui/react";
+import TenderReviewTab from "./TenderReviewTab";
+
+interface TenderMobileReviewTabProps {
+  tenderId: string;
+}
+
+const TenderMobileReviewTab: React.FC<TenderMobileReviewTabProps> = ({ tenderId }) => {
+  return (
+    <Box h="100%" overflow="hidden">
+      <TenderReviewTab tenderId={tenderId} />
+    </Box>
+  );
+};
+
+export default TenderMobileReviewTab;

--- a/client/src/components/Tender/TenderReviewTab.tsx
+++ b/client/src/components/Tender/TenderReviewTab.tsx
@@ -17,6 +17,7 @@ import {
 } from "@chakra-ui/react";
 import { FiChevronDown, FiEdit2, FiTrash2 } from "react-icons/fi";
 import { gql, useQuery, useMutation } from "@apollo/client";
+import { STATUS_LABELS, LineItemStatus } from "../TenderPricing/statusConstants";
 
 // Inline relative time — no external dependency, follows project pattern
 const relativeTime = (dateStr: string): string => {
@@ -43,6 +44,7 @@ const TENDER_REVIEW_QUERY = gql`
         rowDescription
         action
         changedFields
+        statusTo
         changedBy {
           _id
           name
@@ -137,6 +139,7 @@ interface AuditEvent {
   rowDescription: string;
   action: "row_added" | "row_deleted" | "row_updated";
   changedFields: string[];
+  statusTo?: string | null;
   changedBy?: { _id: string; name: string } | null;
   changedAt: string;
 }
@@ -178,6 +181,20 @@ function buildActionLabel(event: AuditEvent): string {
   const actor = event.changedBy?.name ?? "Someone";
   if (event.action === "row_added") return `${actor} added row "${event.rowDescription}"`;
   if (event.action === "row_deleted") return `${actor} deleted row "${event.rowDescription}"`;
+
+  // Status-only change — descriptive label
+  if (event.statusTo && event.changedFields.length === 1 && event.changedFields[0] === "status") {
+    const label = STATUS_LABELS[event.statusTo as LineItemStatus] ?? event.statusTo;
+    return `${actor} moved "${event.rowDescription}" to ${label}`;
+  }
+
+  // Status change alongside other fields
+  if (event.statusTo) {
+    const label = STATUS_LABELS[event.statusTo as LineItemStatus] ?? event.statusTo;
+    const otherFields = event.changedFields.filter((f) => f !== "status").join(", ");
+    return `${actor} updated "${event.rowDescription}" — ${otherFields}, moved to ${label}`;
+  }
+
   const fields = event.changedFields.join(", ");
   return `${actor} updated "${event.rowDescription}" — ${fields}`;
 }

--- a/client/src/components/Tender/TenderReviewTab.tsx
+++ b/client/src/components/Tender/TenderReviewTab.tsx
@@ -1,5 +1,11 @@
 import React, { useState, useRef, useEffect } from "react";
 import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
   Box,
   Badge,
   Button,
@@ -17,7 +23,8 @@ import {
 } from "@chakra-ui/react";
 import { FiChevronDown, FiEdit2, FiTrash2 } from "react-icons/fi";
 import { gql, useQuery, useMutation } from "@apollo/client";
-import { STATUS_LABELS, LineItemStatus } from "../TenderPricing/statusConstants";
+import { STATUS_LABELS as LINE_ITEM_STATUS_LABELS, LineItemStatus } from "../TenderPricing/statusConstants";
+import { TenderPricingSheet, TenderPricingRowType } from "../TenderPricing/types";
 
 // Inline relative time — no external dependency, follows project pattern
 const relativeTime = (dateStr: string): string => {
@@ -184,13 +191,13 @@ function buildActionLabel(event: AuditEvent): string {
 
   // Status-only change — descriptive label
   if (event.statusTo && event.changedFields.length === 1 && event.changedFields[0] === "status") {
-    const label = STATUS_LABELS[event.statusTo as LineItemStatus] ?? event.statusTo;
+    const label = LINE_ITEM_STATUS_LABELS[event.statusTo as LineItemStatus] ?? event.statusTo;
     return `${actor} moved "${event.rowDescription}" to ${label}`;
   }
 
   // Status change alongside other fields
   if (event.statusTo) {
-    const label = STATUS_LABELS[event.statusTo as LineItemStatus] ?? event.statusTo;
+    const label = LINE_ITEM_STATUS_LABELS[event.statusTo as LineItemStatus] ?? event.statusTo;
     const otherFields = event.changedFields.filter((f) => f !== "status").join(", ");
     return `${actor} updated "${event.rowDescription}" — ${otherFields}, moved to ${label}`;
   }
@@ -298,11 +305,22 @@ const CommentItem: React.FC<CommentItemProps> = ({ comment, currentUserId, tende
 interface TenderReviewTabProps {
   tenderId: string;
   currentUserId?: string;
+  sheet?: TenderPricingSheet | null;
 }
 
-const TenderReviewTab: React.FC<TenderReviewTabProps> = ({ tenderId, currentUserId }) => {
+const TenderReviewTab: React.FC<TenderReviewTabProps> = ({ tenderId, currentUserId, sheet }) => {
   const [commentText, setCommentText] = useState("");
+  const [pendingApproval, setPendingApproval] = useState<ReviewStatus | null>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+
+  // Count line items not yet approved
+  const unapprovedCount = React.useMemo(() => {
+    if (!sheet) return 0;
+    return sheet.rows.filter(
+      (r) => r.type === TenderPricingRowType.Item && r.status !== "approved"
+    ).length;
+  }, [sheet]);
 
   const { data, loading } = useQuery(TENDER_REVIEW_QUERY, { variables: { tenderId } });
   const [setStatus] = useMutation(SET_STATUS, {
@@ -406,7 +424,13 @@ const TenderReviewTab: React.FC<TenderReviewTabProps> = ({ tenderId, currentUser
             {(["draft", "in_review", "approved"] as ReviewStatus[]).map((s) => (
               <MenuItem
                 key={s}
-                onClick={() => setStatus({ variables: { tenderId, status: s } })}
+                onClick={() => {
+                  if (s === "approved" && unapprovedCount > 0) {
+                    setPendingApproval(s);
+                  } else {
+                    setStatus({ variables: { tenderId, status: s } });
+                  }
+                }}
                 fontWeight={s === status ? "bold" : "normal"}
               >
                 {STATUS_LABELS[s]}
@@ -463,6 +487,44 @@ const TenderReviewTab: React.FC<TenderReviewTabProps> = ({ tenderId, currentUser
           </Button>
         </Flex>
       </Box>
+
+      {/* Approve confirmation dialog */}
+      <AlertDialog
+        isOpen={!!pendingApproval}
+        leastDestructiveRef={cancelRef}
+        onClose={() => setPendingApproval(null)}
+        isCentered
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize="md" fontWeight="semibold">
+              Approve review with unapproved items?
+            </AlertDialogHeader>
+            <AlertDialogBody fontSize="sm">
+              {unapprovedCount} line item{unapprovedCount === 1 ? " is" : "s are"} not yet marked as approved.
+              You can still approve the review, but it&apos;s generally a good idea to approve all line items first.
+            </AlertDialogBody>
+            <AlertDialogFooter>
+              <Button ref={cancelRef} size="sm" onClick={() => setPendingApproval(null)}>
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                colorScheme="green"
+                ml={3}
+                onClick={() => {
+                  if (pendingApproval) {
+                    setStatus({ variables: { tenderId, status: pendingApproval } });
+                  }
+                  setPendingApproval(null);
+                }}
+              >
+                Approve anyway
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
     </Flex>
   );
 };

--- a/client/src/components/Tender/TenderReviewTab.tsx
+++ b/client/src/components/Tender/TenderReviewTab.tsx
@@ -314,9 +314,10 @@ const TenderReviewTab: React.FC<TenderReviewTabProps> = ({ tenderId, currentUser
   const cancelRef = useRef<HTMLButtonElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
 
-  // Count line items not yet approved
+  // Count line items not yet approved. Returns null if sheet hasn't loaded yet
+  // so the approve warning dialog still fires (better safe than silently approving).
   const unapprovedCount = React.useMemo(() => {
-    if (!sheet) return 0;
+    if (!sheet) return null;
     return sheet.rows.filter(
       (r) => r.type === TenderPricingRowType.Item && r.status !== "approved"
     ).length;
@@ -425,7 +426,7 @@ const TenderReviewTab: React.FC<TenderReviewTabProps> = ({ tenderId, currentUser
               <MenuItem
                 key={s}
                 onClick={() => {
-                  if (s === "approved" && unapprovedCount > 0) {
+                  if (s === "approved" && (unapprovedCount === null || unapprovedCount > 0)) {
                     setPendingApproval(s);
                   } else {
                     setStatus({ variables: { tenderId, status: s } });
@@ -501,8 +502,12 @@ const TenderReviewTab: React.FC<TenderReviewTabProps> = ({ tenderId, currentUser
               Approve review with unapproved items?
             </AlertDialogHeader>
             <AlertDialogBody fontSize="sm">
-              {unapprovedCount} line item{unapprovedCount === 1 ? " is" : "s are"} not yet marked as approved.
-              You can still approve the review, but it&apos;s generally a good idea to approve all line items first.
+              {unapprovedCount === null ? (
+                <>The pricing sheet is still loading. You can still approve the review, but you may want to wait and verify all line items are approved first.</>
+              ) : (
+                <>{unapprovedCount} line item{unapprovedCount === 1 ? " is" : "s are"} not yet marked as approved.
+                You can still approve the review, but it&apos;s generally a good idea to approve all line items first.</>
+              )}
             </AlertDialogBody>
             <AlertDialogFooter>
               <Button ref={cancelRef} size="sm" onClick={() => setPendingApproval(null)}>

--- a/client/src/components/Tender/TenderReviewTab.tsx
+++ b/client/src/components/Tender/TenderReviewTab.tsx
@@ -298,7 +298,10 @@ const TenderReviewTab: React.FC<TenderReviewTabProps> = ({ tenderId, currentUser
   const review = data?.tenderReview;
   const status: ReviewStatus = review?.status ?? "draft";
 
-  // Build sorted timeline
+  // Build sorted timeline, collapsing consecutive audit events on the same row
+  // by the same user within COLLAPSE_WINDOW_MS into a single entry.
+  const COLLAPSE_WINDOW_MS = 2000;
+
   const timeline: TimelineItem[] = React.useMemo(() => {
     if (!review) return [];
     const items: TimelineItem[] = [
@@ -313,7 +316,31 @@ const TenderReviewTab: React.FC<TenderReviewTabProps> = ({ tenderId, currentUser
         data: c,
       })),
     ];
-    return items.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+    items.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+    // Collapse nearby audit events from the same user on the same row
+    const collapsed: TimelineItem[] = [];
+    for (const item of items) {
+      const prev = collapsed[collapsed.length - 1];
+      if (
+        item.kind === "audit" &&
+        prev?.kind === "audit" &&
+        prev.data.changedBy?._id === item.data.changedBy?._id &&
+        prev.data.rowDescription === item.data.rowDescription &&
+        prev.data.action === item.data.action &&
+        item.timestamp.getTime() - prev.timestamp.getTime() < COLLAPSE_WINDOW_MS
+      ) {
+        // Merge changedFields into the previous event
+        const mergedFields = [...new Set([...prev.data.changedFields, ...item.data.changedFields])];
+        collapsed[collapsed.length - 1] = {
+          ...prev,
+          data: { ...prev.data, changedFields: mergedFields },
+        };
+      } else {
+        collapsed.push(item);
+      }
+    }
+    return collapsed;
   }, [review]);
 
   useEffect(() => {

--- a/client/src/components/Tender/TenderReviewTab.tsx
+++ b/client/src/components/Tender/TenderReviewTab.tsx
@@ -1,0 +1,426 @@
+import React, { useState, useRef, useEffect } from "react";
+import {
+  Box,
+  Badge,
+  Button,
+  Flex,
+  HStack,
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Spinner,
+  Text,
+  Textarea,
+  VStack,
+} from "@chakra-ui/react";
+import { FiChevronDown, FiEdit2, FiTrash2 } from "react-icons/fi";
+import { gql, useQuery, useMutation } from "@apollo/client";
+
+// Inline relative time — no external dependency, follows project pattern
+const relativeTime = (dateStr: string): string => {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+};
+
+// ─── GQL ─────────────────────────────────────────────────────────────────────
+
+const TENDER_REVIEW_QUERY = gql`
+  query TenderReview($tenderId: ID!) {
+    tenderReview(tenderId: $tenderId) {
+      _id
+      status
+      auditLog {
+        _id
+        rowId
+        rowDescription
+        action
+        changedFields
+        changedBy {
+          _id
+          name
+        }
+        changedAt
+      }
+      comments {
+        _id
+        content
+        author {
+          _id
+          name
+        }
+        createdAt
+        editedAt
+      }
+    }
+  }
+`;
+
+const SET_STATUS = gql`
+  mutation TenderReviewSetStatus($tenderId: ID!, $status: String!) {
+    tenderReviewSetStatus(tenderId: $tenderId, status: $status) {
+      _id
+      status
+    }
+  }
+`;
+
+const ADD_COMMENT = gql`
+  mutation TenderReviewAddComment($tenderId: ID!, $content: String!) {
+    tenderReviewAddComment(tenderId: $tenderId, content: $content) {
+      _id
+      status
+      auditLog {
+        _id
+        rowId
+        rowDescription
+        action
+        changedFields
+        changedBy { _id name }
+        changedAt
+      }
+      comments {
+        _id
+        content
+        author { _id name }
+        createdAt
+        editedAt
+      }
+    }
+  }
+`;
+
+const EDIT_COMMENT = gql`
+  mutation TenderReviewEditComment($tenderId: ID!, $commentId: ID!, $content: String!) {
+    tenderReviewEditComment(tenderId: $tenderId, commentId: $commentId, content: $content) {
+      _id
+      comments {
+        _id
+        content
+        author { _id name }
+        createdAt
+        editedAt
+      }
+    }
+  }
+`;
+
+const DELETE_COMMENT = gql`
+  mutation TenderReviewDeleteComment($tenderId: ID!, $commentId: ID!) {
+    tenderReviewDeleteComment(tenderId: $tenderId, commentId: $commentId) {
+      _id
+      comments {
+        _id
+        content
+        author { _id name }
+        createdAt
+        editedAt
+      }
+    }
+  }
+`;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type ReviewStatus = "draft" | "in_review" | "approved";
+
+interface AuditEvent {
+  __typename: "TenderAuditEventClass";
+  _id: string;
+  rowDescription: string;
+  action: "row_added" | "row_deleted" | "row_updated";
+  changedFields: string[];
+  changedBy?: { _id: string; name: string } | null;
+  changedAt: string;
+}
+
+interface ReviewComment {
+  __typename: "TenderReviewCommentClass";
+  _id: string;
+  content: string;
+  author?: { _id: string; name: string } | null;
+  createdAt: string;
+  editedAt?: string | null;
+}
+
+type TimelineItem =
+  | { kind: "audit"; timestamp: Date; data: AuditEvent }
+  | { kind: "comment"; timestamp: Date; data: ReviewComment };
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const STATUS_COLORS: Record<ReviewStatus, string> = {
+  draft: "gray",
+  in_review: "blue",
+  approved: "green",
+};
+
+const STATUS_LABELS: Record<ReviewStatus, string> = {
+  draft: "Draft",
+  in_review: "In Review",
+  approved: "Approved",
+};
+
+const NEXT_STATUS_LABEL: Record<ReviewStatus, string> = {
+  draft: "Mark as In Review",
+  in_review: "Mark as Approved",
+  approved: "Back to Draft",
+};
+
+function buildActionLabel(event: AuditEvent): string {
+  const actor = event.changedBy?.name ?? "Someone";
+  if (event.action === "row_added") return `${actor} added row "${event.rowDescription}"`;
+  if (event.action === "row_deleted") return `${actor} deleted row "${event.rowDescription}"`;
+  const fields = event.changedFields.join(", ");
+  return `${actor} updated "${event.rowDescription}" — ${fields}`;
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+const AuditEventItem: React.FC<{ event: AuditEvent }> = ({ event }) => (
+  <Flex gap={2} align="flex-start" py={1}>
+    <Box mt="5px" w="8px" h="8px" borderRadius="full" bg="gray.400" flexShrink={0} />
+    <Box>
+      <Text fontSize="sm" color="gray.700">{buildActionLabel(event)}</Text>
+      <Text fontSize="xs" color="gray.400">
+        {relativeTime(event.changedAt)}
+      </Text>
+    </Box>
+  </Flex>
+);
+
+interface CommentItemProps {
+  comment: ReviewComment;
+  currentUserId?: string;
+  tenderId: string;
+}
+
+const CommentItem: React.FC<CommentItemProps> = ({ comment, currentUserId, tenderId }) => {
+  const [editing, setEditing] = useState(false);
+  const [editText, setEditText] = useState(comment.content);
+  const isOwn = currentUserId && comment.author?._id === currentUserId;
+
+  const [editComment] = useMutation(EDIT_COMMENT);
+  const [deleteComment] = useMutation(DELETE_COMMENT);
+
+  const handleSaveEdit = async () => {
+    if (!editText.trim()) return;
+    await editComment({ variables: { tenderId, commentId: comment._id, content: editText.trim() } });
+    setEditing(false);
+  };
+
+  return (
+    <Box
+      bg="gray.50"
+      border="1px solid"
+      borderColor="gray.200"
+      borderRadius="md"
+      px={3}
+      py={2}
+      my={1}
+    >
+      <Flex justify="space-between" align="flex-start">
+        <Text fontSize="xs" fontWeight="semibold" color="gray.600">
+          {comment.author?.name ?? "Unknown"}
+        </Text>
+        {isOwn && !editing && (
+          <HStack spacing={1}>
+            <IconButton
+              aria-label="Edit comment"
+              icon={<FiEdit2 size={12} />}
+              size="xs"
+              variant="ghost"
+              onClick={() => setEditing(true)}
+            />
+            <IconButton
+              aria-label="Delete comment"
+              icon={<FiTrash2 size={12} />}
+              size="xs"
+              variant="ghost"
+              colorScheme="red"
+              onClick={() =>
+                deleteComment({ variables: { tenderId, commentId: comment._id } })
+              }
+            />
+          </HStack>
+        )}
+      </Flex>
+      {editing ? (
+        <VStack align="stretch" mt={1} spacing={1}>
+          <Textarea
+            value={editText}
+            onChange={(e) => setEditText(e.target.value)}
+            size="sm"
+            rows={2}
+          />
+          <HStack>
+            <Button size="xs" colorScheme="blue" onClick={handleSaveEdit}>Save</Button>
+            <Button size="xs" variant="ghost" onClick={() => { setEditing(false); setEditText(comment.content); }}>Cancel</Button>
+          </HStack>
+        </VStack>
+      ) : (
+        <Text fontSize="sm" mt={1} whiteSpace="pre-wrap">{comment.content}</Text>
+      )}
+      <Text fontSize="xs" color="gray.400" mt={1}>
+        {relativeTime(comment.createdAt)}
+        {comment.editedAt && " (edited)"}
+      </Text>
+    </Box>
+  );
+};
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface TenderReviewTabProps {
+  tenderId: string;
+  currentUserId?: string;
+}
+
+const TenderReviewTab: React.FC<TenderReviewTabProps> = ({ tenderId, currentUserId }) => {
+  const [commentText, setCommentText] = useState("");
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const { data, loading } = useQuery(TENDER_REVIEW_QUERY, { variables: { tenderId } });
+  const [setStatus] = useMutation(SET_STATUS, {
+    refetchQueries: [{ query: TENDER_REVIEW_QUERY, variables: { tenderId } }],
+  });
+  const [addComment, { loading: addingComment }] = useMutation(ADD_COMMENT, {
+    refetchQueries: [{ query: TENDER_REVIEW_QUERY, variables: { tenderId } }],
+  });
+
+  const review = data?.tenderReview;
+  const status: ReviewStatus = review?.status ?? "draft";
+
+  // Build sorted timeline
+  const timeline: TimelineItem[] = React.useMemo(() => {
+    if (!review) return [];
+    const items: TimelineItem[] = [
+      ...(review.auditLog as AuditEvent[]).map((e: AuditEvent) => ({
+        kind: "audit" as const,
+        timestamp: new Date(e.changedAt),
+        data: e,
+      })),
+      ...(review.comments as ReviewComment[]).map((c: ReviewComment) => ({
+        kind: "comment" as const,
+        timestamp: new Date(c.createdAt),
+        data: c,
+      })),
+    ];
+    return items.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  }, [review]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [timeline.length]);
+
+  const handlePostComment = async () => {
+    const content = commentText.trim();
+    if (!content) return;
+    setCommentText("");
+    await addComment({ variables: { tenderId, content } });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handlePostComment();
+  };
+
+  if (loading) {
+    return (
+      <Flex h="200px" align="center" justify="center">
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex direction="column" h="100%" overflow="hidden">
+      {/* Status bar */}
+      <Flex
+        px={4}
+        py={2}
+        borderBottom="1px solid"
+        borderColor="gray.200"
+        align="center"
+        gap={3}
+        flexShrink={0}
+      >
+        <Badge colorScheme={STATUS_COLORS[status]} fontSize="xs" px={2} py={1}>
+          {STATUS_LABELS[status]}
+        </Badge>
+        <Menu>
+          <MenuButton as={Button} size="xs" variant="outline" rightIcon={<FiChevronDown />}>
+            {NEXT_STATUS_LABEL[status]}
+          </MenuButton>
+          <MenuList fontSize="sm">
+            {(["draft", "in_review", "approved"] as ReviewStatus[]).map((s) => (
+              <MenuItem
+                key={s}
+                onClick={() => setStatus({ variables: { tenderId, status: s } })}
+                fontWeight={s === status ? "bold" : "normal"}
+              >
+                {STATUS_LABELS[s]}
+              </MenuItem>
+            ))}
+          </MenuList>
+        </Menu>
+      </Flex>
+
+      {/* Timeline */}
+      <Box flex={1} overflowY="auto" px={4} py={3}>
+        {timeline.length === 0 ? (
+          <Text fontSize="sm" color="gray.400" textAlign="center" mt={8}>
+            No activity yet — changes to this sheet will appear here.
+          </Text>
+        ) : (
+          timeline.map((item) =>
+            item.kind === "audit" ? (
+              <AuditEventItem key={item.data._id} event={item.data} />
+            ) : (
+              <CommentItem
+                key={item.data._id}
+                comment={item.data}
+                currentUserId={currentUserId}
+                tenderId={tenderId}
+              />
+            )
+          )
+        )}
+        <div ref={bottomRef} />
+      </Box>
+
+      {/* Comment input */}
+      <Box px={4} py={3} borderTop="1px solid" borderColor="gray.200" flexShrink={0}>
+        <Flex gap={2} align="flex-end">
+          <Textarea
+            value={commentText}
+            onChange={(e) => setCommentText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Add a comment... (Cmd+Enter to post)"
+            size="sm"
+            rows={2}
+            resize="none"
+            flex={1}
+          />
+          <Button
+            size="sm"
+            colorScheme="blue"
+            onClick={handlePostComment}
+            isLoading={addingComment}
+            isDisabled={!commentText.trim()}
+          >
+            Post
+          </Button>
+        </Flex>
+      </Box>
+    </Flex>
+  );
+};
+
+export default TenderReviewTab;

--- a/client/src/components/TenderPricing/LineItemDetail.tsx
+++ b/client/src/components/TenderPricing/LineItemDetail.tsx
@@ -464,6 +464,34 @@ const LineItemDetail: React.FC<LineItemDetailProps> = ({
           </FormControl>
         </Grid>
 
+        {/* ── Rate Buildup CTA (no-buildup only) ── */}
+        {!hasRateBuildup && (
+          <Box
+            bg="blue.50" border="1px dashed" borderColor="blue.200"
+            rounded="lg" p={4} mb={4} textAlign="center"
+          >
+            <Text fontSize="sm" fontWeight="medium" color="blue.700" mb={1}>
+              Use a Rate Buildup Template
+            </Text>
+            <Text fontSize="xs" color="blue.500" mb={3}>
+              Build your unit price from crew rates, equipment, materials, and production rates
+            </Text>
+            <AttachTemplateButton
+              rowUnit={row.unit}
+              onAttach={(templateDoc) => {
+                const snapshot = snapshotFromTemplate(templateDoc);
+                onUpdate(row._id, {
+                  rateBuildupSnapshot: JSON.stringify(snapshot),
+                  unit: row.unit || templateDoc.defaultUnit || null,
+                });
+              }}
+            />
+            <Text fontSize="10px" color="gray.400" mt={3}>
+              or enter a unit price manually below
+            </Text>
+          </Box>
+        )}
+
         {/* ── PRICING SECTION (no-buildup only) — after details ── */}
         {!hasRateBuildup && (
           <Box

--- a/client/src/components/TenderPricing/LineItemDetail.tsx
+++ b/client/src/components/TenderPricing/LineItemDetail.tsx
@@ -608,49 +608,34 @@ const LineItemDetail: React.FC<LineItemDetailProps> = ({
           </Box>
         )}
 
-        {/* Markup */}
-        <Grid templateColumns="1fr 1fr" gap={3} mb={3}>
-          <FormControl>
-            <FormLabel fontSize="xs" color="gray.400" fontWeight="medium" mb={1}>Markup Override</FormLabel>
-            <InputGroup size="sm">
-              <InputLeftAddon
-                bg={hasMarkupOverride ? "orange.50" : "gray.100"}
-                color={hasMarkupOverride ? "orange.600" : "gray.500"}
-                borderColor={hasMarkupOverride ? "orange.200" : "gray.200"}
-                fontSize="xs" px={2}
-              >
-                %
-              </InputLeftAddon>
-              <Input
-                value={markup}
-                onChange={(e) => setMarkup(e.target.value)}
-                onBlur={() => commitMarkup(markup)}
-                placeholder="default"
-                bg="gray.50"
-                borderColor={hasMarkupOverride ? "orange.200" : undefined}
-                _focus={{ bg: "white", borderColor: "orange.400", boxShadow: "0 0 0 1px #fb923c" }}
-              />
-            </InputGroup>
-          </FormControl>
-          <Box>
-            <Text fontSize="xs" color="gray.400" fontWeight="medium" mb={1}>Effective Markup</Text>
-            <Flex
-              align="center" h="32px" px={3}
+        {/* Markup — compact inline row */}
+        <Flex align="center" gap={3} mb={3} px={1}>
+          <Text fontSize="xs" color="gray.400" fontWeight="medium" whiteSpace="nowrap">Markup</Text>
+          <Text fontSize="sm" fontWeight="semibold" color={hasMarkupOverride ? "orange.700" : "gray.600"}>
+            {effectiveMarkup}%
+          </Text>
+          <Flex align="center" gap={1}>
+            <Text fontSize="xs" color="gray.400" whiteSpace="nowrap">Override:</Text>
+            <Input
+              size="xs"
+              w="52px"
+              value={markup}
+              onChange={(e) => setMarkup(e.target.value)}
+              onBlur={() => commitMarkup(markup)}
+              placeholder="—"
+              textAlign="center"
               bg={hasMarkupOverride ? "orange.50" : "gray.50"}
-              border="1px solid" borderColor={hasMarkupOverride ? "orange.200" : "gray.200"}
-              rounded="md"
-            >
-              <Text fontSize="sm" fontWeight="semibold" color={hasMarkupOverride ? "orange.700" : "gray.600"}>
-                {effectiveMarkup}%
-              </Text>
-              {hasMarkupOverride && (
-                <Text fontSize="xs" color="gray.400" ml={1.5}>
-                  base {defaultMarkupPct}%{previewRow.markupOverride! > 0 ? " +" : " "}{previewRow.markupOverride}%
-                </Text>
-              )}
-            </Flex>
-          </Box>
-        </Grid>
+              borderColor={hasMarkupOverride ? "orange.200" : "gray.200"}
+              _focus={{ bg: "white", borderColor: "orange.400", boxShadow: "0 0 0 1px #fb923c" }}
+            />
+            <Text fontSize="xs" color="gray.400">%</Text>
+          </Flex>
+          {hasMarkupOverride && (
+            <Text fontSize="10px" color="gray.400" whiteSpace="nowrap">
+              (base {defaultMarkupPct}%)
+            </Text>
+          )}
+        </Flex>
 
         {/* Notes */}
         <FormControl mb={4}>

--- a/client/src/components/TenderPricing/LineItemDetail.tsx
+++ b/client/src/components/TenderPricing/LineItemDetail.tsx
@@ -396,42 +396,75 @@ const LineItemDetail: React.FC<LineItemDetailProps> = ({
         />
       </Flex>
 
-      {/* ── Status bar ─────────────────────────────────────────────── */}
-      <Flex px={4} py={2} gap={2} borderBottom="1px solid" borderColor="gray.100" flexShrink={0}>
-        {LINE_ITEM_STATUSES.map((s) => {
-          const active = s === ((row.status as LineItemStatus) ?? "not_started");
-          return (
-            <Flex
-              key={s}
-              align="center"
-              gap={1.5}
-              px={3}
-              py={1}
-              borderRadius="full"
-              cursor="pointer"
-              border="1px solid"
-              borderColor={active ? STATUS_COLORS[s] : "gray.200"}
-              bg={active ? `${STATUS_COLORS[s]}18` : "transparent"}
-              _hover={{ borderColor: STATUS_COLORS[s] }}
-              transition="all 0.15s"
-              onClick={() => onUpdate(row._id, { status: s })}
-            >
-              <Box w="7px" h="7px" borderRadius="full" bg={STATUS_COLORS[s]} flexShrink={0} />
-              <Text fontSize="xs" fontWeight={active ? "semibold" : "normal"} color={active ? "gray.800" : "gray.500"} whiteSpace="nowrap">
-                {STATUS_LABELS[s]}
-              </Text>
-            </Flex>
-          );
-        })}
-      </Flex>
-
       {/* ── Form ────────────────────────────────────────────────────── */}
       <Box px={5} pb={5} overflowY="auto" flex={1} overscrollBehavior="contain">
 
         {/* ── Line item details ── */}
         <Box pt={4} mb={5}>
 
-        {/* ── PRICING SECTION (no-buildup only) ── */}
+        {/* ── DETAILS SECTION with status pills ── */}
+        <Flex align="center" justify="space-between" mb={2}>
+          <Text fontSize="xs" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wider">
+            Details
+          </Text>
+          <Flex gap={1.5} flexWrap="wrap">
+            {LINE_ITEM_STATUSES.map((s) => {
+              const active = s === ((row.status as LineItemStatus) ?? "not_started");
+              return (
+                <Flex
+                  key={s}
+                  align="center"
+                  gap={1}
+                  px={2}
+                  py={0.5}
+                  borderRadius="full"
+                  cursor="pointer"
+                  border="1px solid"
+                  borderColor={active ? STATUS_COLORS[s] : "gray.200"}
+                  bg={active ? `${STATUS_COLORS[s]}18` : "transparent"}
+                  _hover={{ borderColor: STATUS_COLORS[s] }}
+                  transition="all 0.15s"
+                  onClick={() => onUpdate(row._id, { status: s })}
+                >
+                  <Box w="6px" h="6px" borderRadius="full" bg={STATUS_COLORS[s]} flexShrink={0} />
+                  <Text fontSize="10px" fontWeight={active ? "semibold" : "normal"} color={active ? "gray.800" : "gray.500"} whiteSpace="nowrap">
+                    {STATUS_LABELS[s]}
+                  </Text>
+                </Flex>
+              );
+            })}
+          </Flex>
+        </Flex>
+
+        {/* Item # + Description */}
+        <Grid templateColumns="80px 1fr" gap={3} mb={3}>
+          <FormControl>
+            <FormLabel fontSize="xs" color="gray.400" fontWeight="medium" mb={1}>Item #</FormLabel>
+            <Input
+              size="sm"
+              value={itemNumber}
+              onChange={(e) => setItemNumber(e.target.value)}
+              onBlur={() => commitStr("itemNumber", itemNumber)}
+              placeholder="—"
+              bg="gray.50"
+              _focus={{ bg: "white", borderColor: "orange.400", boxShadow: "0 0 0 1px #fb923c" }}
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel fontSize="xs" color="gray.400" fontWeight="medium" mb={1}>Description</FormLabel>
+            <Input
+              size="sm"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              onBlur={() => commitStr("description", description)}
+              placeholder="Line item description"
+              bg="gray.50"
+              _focus={{ bg: "white", borderColor: "orange.400", boxShadow: "0 0 0 1px #fb923c" }}
+            />
+          </FormControl>
+        </Grid>
+
+        {/* ── PRICING SECTION (no-buildup only) — after details ── */}
         {!hasRateBuildup && (
           <Box
             bg="orange.50" border="1px solid" borderColor="orange.200"
@@ -499,39 +532,6 @@ const LineItemDetail: React.FC<LineItemDetailProps> = ({
             </Grid>
           </Box>
         )}
-
-        {/* ── DETAILS SECTION ── */}
-        <Text fontSize="xs" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wider" mb={2}>
-          Details
-        </Text>
-
-        {/* Description + Item # */}
-        <Grid templateColumns="1fr 80px" gap={3} mb={3}>
-          <FormControl>
-            <FormLabel fontSize="xs" color="gray.400" fontWeight="medium" mb={1}>Description</FormLabel>
-            <Input
-              size="sm"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              onBlur={() => commitStr("description", description)}
-              placeholder="Line item description"
-              bg="gray.50"
-              _focus={{ bg: "white", borderColor: "orange.400", boxShadow: "0 0 0 1px #fb923c" }}
-            />
-          </FormControl>
-          <FormControl>
-            <FormLabel fontSize="xs" color="gray.400" fontWeight="medium" mb={1}>Item #</FormLabel>
-            <Input
-              size="sm"
-              value={itemNumber}
-              onChange={(e) => setItemNumber(e.target.value)}
-              onBlur={() => commitStr("itemNumber", itemNumber)}
-              placeholder="—"
-              bg="gray.50"
-              _focus={{ bg: "white", borderColor: "orange.400", boxShadow: "0 0 0 1px #fb923c" }}
-            />
-          </FormControl>
-        </Grid>
 
         {/* Qty + Unit — featured card when there IS a buildup */}
         {hasRateBuildup && (

--- a/client/src/components/TenderPricing/LineItemDetail.tsx
+++ b/client/src/components/TenderPricing/LineItemDetail.tsx
@@ -609,7 +609,13 @@ const LineItemDetail: React.FC<LineItemDetailProps> = ({
         )}
 
         {/* Markup — compact inline row */}
-        <Flex align="center" gap={3} mb={3} px={1} justify="flex-end">
+        <Flex align="center" gap={3} mb={3} px={1}>
+          {hasMarkupOverride && (
+            <Text fontSize="10px" color="gray.400" whiteSpace="nowrap">
+              (base {defaultMarkupPct}%)
+            </Text>
+          )}
+          <Box flex={1} />
           <Text fontSize="xs" color="gray.400" fontWeight="medium" whiteSpace="nowrap">Markup</Text>
           <Text fontSize="sm" fontWeight="semibold" color={hasMarkupOverride ? "orange.700" : "gray.600"}>
             {effectiveMarkup}%
@@ -630,11 +636,6 @@ const LineItemDetail: React.FC<LineItemDetailProps> = ({
             />
             <Text fontSize="xs" color="gray.400">%</Text>
           </Flex>
-          {hasMarkupOverride && (
-            <Text fontSize="10px" color="gray.400" whiteSpace="nowrap">
-              (base {defaultMarkupPct}%)
-            </Text>
-          )}
         </Flex>
 
         {/* Notes */}

--- a/client/src/components/TenderPricing/LineItemDetail.tsx
+++ b/client/src/components/TenderPricing/LineItemDetail.tsx
@@ -24,6 +24,7 @@ import { useSystem } from "../../contexts/System";
 import { TenderPricingRow } from "./types";
 import { TenderFileItem } from "../Tender/types";
 import { computeRow, formatCurrency, formatMarkup } from "./compute";
+import { LineItemStatus, LINE_ITEM_STATUSES, STATUS_LABELS, STATUS_COLORS } from "./statusConstants";
 import type { RateEntry } from "./calculators/types";
 import { RateBuildupTemplatesDocument } from "../../generated/graphql";
 import {
@@ -393,6 +394,35 @@ const LineItemDetail: React.FC<LineItemDetailProps> = ({
           onClick={onClose}
           flexShrink={0}
         />
+      </Flex>
+
+      {/* ── Status bar ─────────────────────────────────────────────── */}
+      <Flex px={4} py={2} gap={2} borderBottom="1px solid" borderColor="gray.100" flexShrink={0}>
+        {LINE_ITEM_STATUSES.map((s) => {
+          const active = s === ((row.status as LineItemStatus) ?? "not_started");
+          return (
+            <Flex
+              key={s}
+              align="center"
+              gap={1.5}
+              px={3}
+              py={1}
+              borderRadius="full"
+              cursor="pointer"
+              border="1px solid"
+              borderColor={active ? STATUS_COLORS[s] : "gray.200"}
+              bg={active ? `${STATUS_COLORS[s]}18` : "transparent"}
+              _hover={{ borderColor: STATUS_COLORS[s] }}
+              transition="all 0.15s"
+              onClick={() => onUpdate(row._id, { status: s })}
+            >
+              <Box w="7px" h="7px" borderRadius="full" bg={STATUS_COLORS[s]} flexShrink={0} />
+              <Text fontSize="xs" fontWeight={active ? "semibold" : "normal"} color={active ? "gray.800" : "gray.500"} whiteSpace="nowrap">
+                {STATUS_LABELS[s]}
+              </Text>
+            </Flex>
+          );
+        })}
       </Flex>
 
       {/* ── Form ────────────────────────────────────────────────────── */}

--- a/client/src/components/TenderPricing/LineItemDetail.tsx
+++ b/client/src/components/TenderPricing/LineItemDetail.tsx
@@ -833,21 +833,7 @@ const LineItemDetail: React.FC<LineItemDetailProps> = ({
                 </Grid>
               </Box>
             </Box>
-          ) : (
-            <Flex align="center" justify="space-between" py={4}>
-              <Text fontSize="xs" color="gray.400">No rate buildup attached</Text>
-              <AttachTemplateButton
-                rowUnit={row.unit}
-                onAttach={(templateDoc) => {
-                  const snapshot = snapshotFromTemplate(templateDoc);
-                  onUpdate(row._id, {
-                    rateBuildupSnapshot: JSON.stringify(snapshot),
-                    unit: row.unit || templateDoc.defaultUnit || null,
-                  });
-                }}
-              />
-            </Flex>
-          )}
+          ) : null}
         </Box>
 
         {/* ── Spec References ── */}

--- a/client/src/components/TenderPricing/LineItemDetail.tsx
+++ b/client/src/components/TenderPricing/LineItemDetail.tsx
@@ -609,7 +609,7 @@ const LineItemDetail: React.FC<LineItemDetailProps> = ({
         )}
 
         {/* Markup — compact inline row */}
-        <Flex align="center" gap={3} mb={3} px={1}>
+        <Flex align="center" gap={3} mb={3} px={1} justify="flex-end">
           <Text fontSize="xs" color="gray.400" fontWeight="medium" whiteSpace="nowrap">Markup</Text>
           <Text fontSize="sm" fontWeight="semibold" color={hasMarkupOverride ? "orange.700" : "gray.600"}>
             {effectiveMarkup}%

--- a/client/src/components/TenderPricing/LineItemDetail.tsx
+++ b/client/src/components/TenderPricing/LineItemDetail.tsx
@@ -609,13 +609,12 @@ const LineItemDetail: React.FC<LineItemDetailProps> = ({
         )}
 
         {/* Markup — compact inline row */}
-        <Flex align="center" gap={3} mb={3} px={1}>
+        <Flex align="center" gap={3} mb={3} px={1} justify="flex-end">
           {hasMarkupOverride && (
             <Text fontSize="10px" color="gray.400" whiteSpace="nowrap">
               (base {defaultMarkupPct}%)
             </Text>
           )}
-          <Box flex={1} />
           <Text fontSize="xs" color="gray.400" fontWeight="medium" whiteSpace="nowrap">Markup</Text>
           <Text fontSize="sm" fontWeight="semibold" color={hasMarkupOverride ? "orange.700" : "gray.600"}>
             {effectiveMarkup}%

--- a/client/src/components/TenderPricing/PricingBoard.tsx
+++ b/client/src/components/TenderPricing/PricingBoard.tsx
@@ -44,8 +44,9 @@ function getScheduleForRow(
   return null;
 }
 
-// Minimum flex so empty columns don't collapse entirely
-const MIN_FLEX = 0.5;
+// Empty columns shrink, non-empty columns share space equally
+const EMPTY_FLEX = 0.3;
+const ACTIVE_FLEX = 1;
 
 // ─── Card ────────────────────────────────────────────────────────────────────
 
@@ -241,7 +242,7 @@ const PricingBoard: React.FC<PricingBoardProps> = ({
               rows={columns[status]}
               allRows={sheet.rows}
               defaultMarkupPct={sheet.defaultMarkupPct}
-              flexValue={Math.max(count, MIN_FLEX)}
+              flexValue={count > 0 ? ACTIVE_FLEX : EMPTY_FLEX}
               onCardClick={setSelectedRow}
             />
           );

--- a/client/src/components/TenderPricing/PricingBoard.tsx
+++ b/client/src/components/TenderPricing/PricingBoard.tsx
@@ -213,7 +213,7 @@ const PricingBoard: React.FC<PricingBoardProps> = ({
   }, [selectedRow, sheet.rows]);
 
   return (
-    <Flex direction="column" h="100%" overflow="hidden" position="relative">
+    <Flex direction="column" h="100%" overflow="hidden">
       {/* Filter bar */}
       {schedules.length > 0 && (
         <Flex px={4} py={2} flexShrink={0} borderBottom="1px solid" borderColor="gray.200">

--- a/client/src/components/TenderPricing/PricingBoard.tsx
+++ b/client/src/components/TenderPricing/PricingBoard.tsx
@@ -1,0 +1,263 @@
+import React, { useMemo, useState } from "react";
+import {
+  Box,
+  Flex,
+  Select,
+  Text,
+} from "@chakra-ui/react";
+import {
+  TenderPricingSheet,
+  TenderPricingRow,
+  TenderPricingRowType,
+} from "./types";
+import { TenderFileItem } from "../Tender/types";
+import { computeRow, formatCurrency } from "./compute";
+import {
+  LineItemStatus,
+  LINE_ITEM_STATUSES,
+  STATUS_COLORS,
+  STATUS_BG,
+  STATUS_LABELS,
+} from "./statusConstants";
+import PricingBoardDrawer from "./PricingBoardDrawer";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface PricingBoardProps {
+  sheet: TenderPricingSheet;
+  tenderId: string;
+  onUpdate: (updated: TenderPricingSheet) => void;
+  onUpdateRow: (rowId: string, data: Record<string, unknown>) => Promise<void>;
+  tenderFiles?: TenderFileItem[];
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function getScheduleForRow(
+  row: TenderPricingRow,
+  rows: TenderPricingRow[]
+): TenderPricingRow | null {
+  const idx = rows.indexOf(row);
+  for (let i = idx - 1; i >= 0; i--) {
+    if (rows[i].type === TenderPricingRowType.Schedule) return rows[i];
+  }
+  return null;
+}
+
+const COLUMN_FLEX: Record<LineItemStatus, number> = {
+  not_started: 2,
+  in_progress: 1,
+  review: 1,
+  approved: 1,
+};
+
+// ─── Card ────────────────────────────────────────────────────────────────────
+
+const BoardCard: React.FC<{
+  row: TenderPricingRow;
+  defaultMarkupPct: number;
+  scheduleName?: string;
+  onClick: () => void;
+}> = ({ row, defaultMarkupPct, scheduleName, onClick }) => {
+  const { lineItemTotal } = computeRow(row, defaultMarkupPct);
+
+  return (
+    <Box
+      bg="white"
+      border="1px solid"
+      borderColor="gray.200"
+      borderRadius="md"
+      px={3}
+      py={2}
+      mb={2}
+      cursor="pointer"
+      _hover={{ shadow: "sm", borderColor: "gray.300" }}
+      onClick={onClick}
+    >
+      <Flex justify="space-between" align="flex-start" gap={2}>
+        <Box flex={1} minW={0}>
+          <Text fontSize="xs" fontWeight="semibold" color="gray.800" noOfLines={1}>
+            {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
+          </Text>
+          <Text fontSize="xs" color="gray.500" mt={0.5}>
+            {row.quantity != null ? `${row.quantity} ${row.unit ?? ""}` : "No qty"}
+          </Text>
+        </Box>
+        <Text fontSize="xs" fontWeight="medium" color={lineItemTotal > 0 ? "gray.700" : "gray.400"} flexShrink={0}>
+          {lineItemTotal > 0 ? formatCurrency(lineItemTotal) : "—"}
+        </Text>
+      </Flex>
+      {scheduleName && (
+        <Text fontSize="9px" color="gray.400" mt={1} noOfLines={1}>{scheduleName}</Text>
+      )}
+    </Box>
+  );
+};
+
+// ─── Column ──────────────────────────────────────────────────────────────────
+
+const BoardColumn: React.FC<{
+  status: LineItemStatus;
+  rows: TenderPricingRow[];
+  allRows: TenderPricingRow[];
+  defaultMarkupPct: number;
+  onCardClick: (row: TenderPricingRow) => void;
+}> = ({ status, rows, allRows, defaultMarkupPct, onCardClick }) => (
+  <Flex
+    direction="column"
+    flex={COLUMN_FLEX[status]}
+    bg={STATUS_BG[status]}
+    borderRadius="lg"
+    overflow="hidden"
+    minW={0}
+  >
+    <Flex
+      px={3}
+      py={2}
+      align="center"
+      gap={2}
+      flexShrink={0}
+    >
+      <Box w="8px" h="8px" borderRadius="full" bg={STATUS_COLORS[status]} flexShrink={0} />
+      <Text
+        fontSize="10px"
+        fontWeight="semibold"
+        textTransform="uppercase"
+        letterSpacing="wide"
+        color="gray.600"
+      >
+        {STATUS_LABELS[status]}
+      </Text>
+      <Box
+        bg="gray.200"
+        borderRadius="full"
+        px={1.5}
+        py={0}
+        fontSize="10px"
+        fontWeight="semibold"
+        color="gray.600"
+      >
+        {rows.length}
+      </Box>
+    </Flex>
+    <Box flex={1} overflowY="auto" px={2} pb={2}>
+      {rows.map((row) => {
+        const sched = getScheduleForRow(row, allRows);
+        return (
+          <BoardCard
+            key={row._id}
+            row={row}
+            defaultMarkupPct={defaultMarkupPct}
+            scheduleName={sched?.description}
+            onClick={() => onCardClick(row)}
+          />
+        );
+      })}
+    </Box>
+  </Flex>
+);
+
+// ─── Board ───────────────────────────────────────────────────────────────────
+
+const PricingBoard: React.FC<PricingBoardProps> = ({
+  sheet,
+  tenderId,
+  onUpdate,
+  onUpdateRow,
+  tenderFiles,
+}) => {
+  const [selectedRow, setSelectedRow] = useState<TenderPricingRow | null>(null);
+  const [scheduleFilter, setScheduleFilter] = useState<string>("all");
+
+  const schedules = useMemo(
+    () => sheet.rows.filter((r) => r.type === TenderPricingRowType.Schedule),
+    [sheet.rows]
+  );
+
+  const items = useMemo(() => {
+    let rows = sheet.rows.filter((r) => r.type === TenderPricingRowType.Item);
+    if (scheduleFilter !== "all") {
+      const schedIdx = sheet.rows.findIndex((r) => r._id === scheduleFilter);
+      if (schedIdx >= 0) {
+        const nextSchedIdx = sheet.rows.findIndex(
+          (r, i) => i > schedIdx && r.type === TenderPricingRowType.Schedule
+        );
+        const endIdx = nextSchedIdx >= 0 ? nextSchedIdx : sheet.rows.length;
+        const schedRowIds = new Set(
+          sheet.rows.slice(schedIdx, endIdx).map((r) => r._id)
+        );
+        rows = rows.filter((r) => schedRowIds.has(r._id));
+      }
+    }
+    return rows;
+  }, [sheet.rows, scheduleFilter]);
+
+  const columns = useMemo(() => {
+    const map: Record<LineItemStatus, TenderPricingRow[]> = {
+      not_started: [],
+      in_progress: [],
+      review: [],
+      approved: [],
+    };
+    for (const row of items) {
+      const status = (row.status as LineItemStatus) ?? "not_started";
+      map[status].push(row);
+    }
+    return map;
+  }, [items]);
+
+  // Keep selectedRow in sync with sheet data
+  const activeRow = useMemo(() => {
+    if (!selectedRow) return null;
+    return sheet.rows.find((r) => r._id === selectedRow._id) ?? null;
+  }, [selectedRow, sheet.rows]);
+
+  return (
+    <Flex direction="column" h="100%" overflow="hidden">
+      {/* Filter bar */}
+      {schedules.length > 0 && (
+        <Flex px={4} py={2} flexShrink={0} borderBottom="1px solid" borderColor="gray.200">
+          <Select
+            size="sm"
+            w="200px"
+            value={scheduleFilter}
+            onChange={(e) => setScheduleFilter(e.target.value)}
+          >
+            <option value="all">All Schedules</option>
+            {schedules.map((s) => (
+              <option key={s._id} value={s._id}>
+                {s.itemNumber ? `${s.itemNumber} — ` : ""}{s.description || "Untitled"}
+              </option>
+            ))}
+          </Select>
+        </Flex>
+      )}
+
+      {/* Columns */}
+      <Flex flex={1} gap={3} p={3} overflow="hidden">
+        {LINE_ITEM_STATUSES.map((status) => (
+          <BoardColumn
+            key={status}
+            status={status}
+            rows={columns[status]}
+            allRows={sheet.rows}
+            defaultMarkupPct={sheet.defaultMarkupPct}
+            onCardClick={setSelectedRow}
+          />
+        ))}
+      </Flex>
+
+      {/* Drawer */}
+      <PricingBoardDrawer
+        row={activeRow}
+        sheet={sheet}
+        tenderId={tenderId}
+        onClose={() => setSelectedRow(null)}
+        onUpdateRow={onUpdateRow}
+        tenderFiles={tenderFiles}
+      />
+    </Flex>
+  );
+};
+
+export default PricingBoard;

--- a/client/src/components/TenderPricing/PricingBoard.tsx
+++ b/client/src/components/TenderPricing/PricingBoard.tsx
@@ -44,12 +44,8 @@ function getScheduleForRow(
   return null;
 }
 
-const COLUMN_FLEX: Record<LineItemStatus, number> = {
-  not_started: 2,
-  in_progress: 1,
-  review: 1,
-  approved: 1,
-};
+// Minimum flex so empty columns don't collapse entirely
+const MIN_FLEX = 0.5;
 
 // ─── Card ────────────────────────────────────────────────────────────────────
 
@@ -101,11 +97,12 @@ const BoardColumn: React.FC<{
   rows: TenderPricingRow[];
   allRows: TenderPricingRow[];
   defaultMarkupPct: number;
+  flexValue: number;
   onCardClick: (row: TenderPricingRow) => void;
-}> = ({ status, rows, allRows, defaultMarkupPct, onCardClick }) => (
+}> = ({ status, rows, allRows, defaultMarkupPct, flexValue, onCardClick }) => (
   <Flex
     direction="column"
-    flex={COLUMN_FLEX[status]}
+    flex={flexValue}
     bg={STATUS_BG[status]}
     borderRadius="lg"
     overflow="hidden"
@@ -235,16 +232,20 @@ const PricingBoard: React.FC<PricingBoardProps> = ({
 
       {/* Columns */}
       <Flex flex={1} gap={3} p={3} overflow="hidden">
-        {LINE_ITEM_STATUSES.map((status) => (
-          <BoardColumn
-            key={status}
-            status={status}
-            rows={columns[status]}
-            allRows={sheet.rows}
-            defaultMarkupPct={sheet.defaultMarkupPct}
-            onCardClick={setSelectedRow}
-          />
-        ))}
+        {LINE_ITEM_STATUSES.map((status) => {
+          const count = columns[status].length;
+          return (
+            <BoardColumn
+              key={status}
+              status={status}
+              rows={columns[status]}
+              allRows={sheet.rows}
+              defaultMarkupPct={sheet.defaultMarkupPct}
+              flexValue={Math.max(count, MIN_FLEX)}
+              onCardClick={setSelectedRow}
+            />
+          );
+        })}
       </Flex>
 
       {/* Bottom drawer */}

--- a/client/src/components/TenderPricing/PricingBoard.tsx
+++ b/client/src/components/TenderPricing/PricingBoard.tsx
@@ -213,7 +213,7 @@ const PricingBoard: React.FC<PricingBoardProps> = ({
   }, [selectedRow, sheet.rows]);
 
   return (
-    <Flex direction="column" h="100%" overflow="hidden">
+    <Flex direction="column" h="100%" overflow="hidden" position="relative">
       {/* Filter bar */}
       {schedules.length > 0 && (
         <Flex px={4} py={2} flexShrink={0} borderBottom="1px solid" borderColor="gray.200">
@@ -247,7 +247,7 @@ const PricingBoard: React.FC<PricingBoardProps> = ({
         ))}
       </Flex>
 
-      {/* Drawer */}
+      {/* Bottom drawer */}
       <PricingBoardDrawer
         row={activeRow}
         sheet={sheet}

--- a/client/src/components/TenderPricing/PricingBoardDrawer.tsx
+++ b/client/src/components/TenderPricing/PricingBoardDrawer.tsx
@@ -2,14 +2,12 @@ import React from "react";
 import {
   Box,
   CloseButton,
-  Divider,
   Flex,
   Text,
 } from "@chakra-ui/react";
 import { TenderPricingRow, TenderPricingSheet } from "./types";
 import { TenderFileItem } from "../Tender/types";
-import { computeRow, formatCurrency } from "./compute";
-import { EditableCell } from "./PricingRow";
+import LineItemDetail from "./LineItemDetail";
 import StatusDot from "./StatusDot";
 import { LineItemStatus, STATUS_LABELS } from "./statusConstants";
 
@@ -25,14 +23,14 @@ interface PricingBoardDrawerProps {
 const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
   row,
   sheet,
+  tenderId,
   onClose,
   onUpdateRow,
+  tenderFiles,
 }) => {
   if (!row) return null;
 
   const status = (row.status as LineItemStatus) ?? "not_started";
-  const { effectiveMarkup, suggestedBidUP, lineItemTotal } = computeRow(row, sheet.defaultMarkupPct);
-  const costUP = (row.unitPrice ?? 0) + (row.extraUnitPrice ?? 0);
 
   return (
     <Box
@@ -40,111 +38,48 @@ const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
       right={0}
       top={0}
       bottom={0}
-      w="400px"
+      w="450px"
       maxW="100vw"
       bg="white"
       boxShadow="-4px 0 16px rgba(0,0,0,0.1)"
       zIndex={20}
       display="flex"
       flexDir="column"
-      overflowY="auto"
     >
-      {/* Header */}
-      <Flex px={4} py={3} align="center" justify="space-between" borderBottom="1px solid" borderColor="gray.200" flexShrink={0}>
-        <Flex align="center" gap={3}>
+      {/* Header with status */}
+      <Flex
+        px={4}
+        py={3}
+        align="center"
+        justify="space-between"
+        borderBottom="1px solid"
+        borderColor="gray.200"
+        flexShrink={0}
+        gap={2}
+      >
+        <Flex align="center" gap={3} flex={1} minW={0}>
           <StatusDot status={status} onChange={(s) => onUpdateRow(row._id, { status: s })} />
-          <Text fontSize="sm" fontWeight="semibold" noOfLines={1}>
-            {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
-          </Text>
+          <Box flex={1} minW={0}>
+            <Text fontSize="sm" fontWeight="semibold" noOfLines={1}>
+              {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
+            </Text>
+            <Text fontSize="xs" color="gray.500">{STATUS_LABELS[status]}</Text>
+          </Box>
         </Flex>
         <CloseButton size="sm" onClick={onClose} />
       </Flex>
 
-      {/* Status label */}
-      <Box px={4} py={2} bg="gray.50" borderBottom="1px solid" borderColor="gray.100">
-        <Text fontSize="xs" color="gray.500">{STATUS_LABELS[status]}</Text>
-      </Box>
-
-      {/* Fields */}
-      <Box px={4} py={4} flex={1}>
-        <Box mb={4}>
-          <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
-            Description
-          </Text>
-          <EditableCell
-            value={row.description}
-            onSave={(v) => onUpdateRow(row._id, { description: v })}
-            placeholder="Enter description"
-            wrap
-          />
-        </Box>
-
-        <Flex gap={4} mb={4}>
-          <Box flex={1}>
-            <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
-              Quantity
-            </Text>
-            <EditableCell
-              value={row.quantity}
-              onSave={(v) => onUpdateRow(row._id, { quantity: parseFloat(v) || null })}
-              placeholder="—"
-            />
-          </Box>
-          <Box flex={1}>
-            <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
-              Unit
-            </Text>
-            <EditableCell
-              value={row.unit}
-              onSave={(v) => onUpdateRow(row._id, { unit: v || null })}
-              placeholder="—"
-            />
-          </Box>
-        </Flex>
-
-        <Divider mb={4} />
-
-        <Flex gap={4} mb={4}>
-          <Box flex={1}>
-            <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
-              Cost Unit Price
-            </Text>
-            <Text fontSize="sm" color={costUP > 0 ? "gray.800" : "gray.400"}>
-              {costUP > 0 ? `$${costUP.toFixed(2)}` : "—"}
-            </Text>
-          </Box>
-          <Box flex={1}>
-            <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
-              Bid Unit Price
-            </Text>
-            <Text fontSize="sm" fontWeight="medium" color={suggestedBidUP > 0 ? "blue.700" : "gray.400"}>
-              {suggestedBidUP > 0 ? `$${suggestedBidUP.toFixed(2)}` : "—"}
-            </Text>
-          </Box>
-        </Flex>
-
-        <Box mb={4}>
-          <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
-            Line Item Total
-          </Text>
-          <Text fontSize="md" fontWeight="semibold" color={lineItemTotal > 0 ? "gray.800" : "gray.400"}>
-            {lineItemTotal > 0 ? formatCurrency(lineItemTotal) : "—"}
-          </Text>
-        </Box>
-
-        <Divider mb={4} />
-
-        <Box mb={4}>
-          <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
-            Notes
-          </Text>
-          <EditableCell
-            value={row.notes}
-            onSave={(v) => onUpdateRow(row._id, { notes: v || null })}
-            placeholder="Add notes..."
-            wrap
-          />
-        </Box>
+      {/* Full LineItemDetail */}
+      <Box flex={1} overflowY="auto">
+        <LineItemDetail
+          row={row}
+          defaultMarkupPct={sheet.defaultMarkupPct}
+          sheetId={sheet._id}
+          tenderId={tenderId}
+          onUpdate={onUpdateRow}
+          onClose={onClose}
+          tenderFiles={tenderFiles}
+        />
       </Box>
     </Box>
   );

--- a/client/src/components/TenderPricing/PricingBoardDrawer.tsx
+++ b/client/src/components/TenderPricing/PricingBoardDrawer.tsx
@@ -28,56 +28,67 @@ const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
   onUpdateRow,
   tenderFiles,
 }) => {
-  if (!row) return null;
-
-  const status = (row.status as LineItemStatus) ?? "not_started";
+  const isOpen = !!row;
+  const status = row ? ((row.status as LineItemStatus) ?? "not_started") : "not_started";
 
   return (
     <Box
+      position="absolute"
+      bottom={0}
+      left={0}
+      right={0}
+      h="55%"
+      bg="white"
       borderTop="1px solid"
       borderColor="gray.200"
-      bg="white"
-      flexShrink={0}
-      maxH="50%"
+      boxShadow="0 -4px 16px rgba(0,0,0,0.08)"
+      transform={isOpen ? "translateY(0)" : "translateY(100%)"}
+      transition="transform 0.25s ease"
       display="flex"
       flexDir="column"
       overflow="hidden"
+      zIndex={10}
     >
-      {/* Header with status */}
-      <Flex
-        px={4}
-        py={2}
-        align="center"
-        justify="space-between"
-        borderBottom="1px solid"
-        borderColor="gray.100"
-        flexShrink={0}
-        gap={2}
-      >
-        <Flex align="center" gap={3} flex={1} minW={0}>
-          <StatusDot status={status} onChange={(s) => onUpdateRow(row._id, { status: s })} />
-          <Box flex={1} minW={0}>
-            <Text fontSize="sm" fontWeight="semibold" noOfLines={1}>
-              {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
-            </Text>
-            <Text fontSize="xs" color="gray.500">{STATUS_LABELS[status]}</Text>
-          </Box>
-        </Flex>
-        <CloseButton size="sm" onClick={onClose} />
-      </Flex>
+      {row && (
+        <>
+          {/* Header with status */}
+          <Flex
+            px={4}
+            py={2}
+            align="center"
+            justify="space-between"
+            borderBottom="1px solid"
+            borderColor="gray.100"
+            flexShrink={0}
+            gap={2}
+            bg="gray.50"
+          >
+            <Flex align="center" gap={3} flex={1} minW={0}>
+              <StatusDot status={status} onChange={(s) => onUpdateRow(row._id, { status: s })} />
+              <Box flex={1} minW={0}>
+                <Text fontSize="sm" fontWeight="semibold" noOfLines={1}>
+                  {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
+                </Text>
+                <Text fontSize="xs" color="gray.500">{STATUS_LABELS[status]}</Text>
+              </Box>
+            </Flex>
+            <CloseButton size="sm" onClick={onClose} />
+          </Flex>
 
-      {/* Full LineItemDetail */}
-      <Box flex={1} overflowY="auto">
-        <LineItemDetail
-          row={row}
-          defaultMarkupPct={sheet.defaultMarkupPct}
-          sheetId={sheet._id}
-          tenderId={tenderId}
-          onUpdate={onUpdateRow}
-          onClose={onClose}
-          tenderFiles={tenderFiles}
-        />
-      </Box>
+          {/* Full LineItemDetail */}
+          <Box flex={1} overflowY="auto">
+            <LineItemDetail
+              row={row}
+              defaultMarkupPct={sheet.defaultMarkupPct}
+              sheetId={sheet._id}
+              tenderId={tenderId}
+              onUpdate={onUpdateRow}
+              onClose={onClose}
+              tenderFiles={tenderFiles}
+            />
+          </Box>
+        </>
+      )}
     </Box>
   );
 };

--- a/client/src/components/TenderPricing/PricingBoardDrawer.tsx
+++ b/client/src/components/TenderPricing/PricingBoardDrawer.tsx
@@ -29,19 +29,17 @@ const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
   return (
     <Drawer isOpen={!!row} onClose={onClose} placement="bottom">
       <DrawerOverlay bg="blackAlpha.300" />
-      <DrawerContent maxH="60vh" borderTopRadius="xl" overflow="hidden">
+      <DrawerContent h="60vh" maxH="60vh" borderTopRadius="xl" overflow="hidden">
         {row && (
-          <Box h="100%" overflow="hidden">
-            <LineItemDetail
-              row={row}
-              defaultMarkupPct={sheet.defaultMarkupPct}
-              sheetId={sheet._id}
-              tenderId={tenderId}
-              onUpdate={onUpdateRow}
-              onClose={onClose}
-              tenderFiles={tenderFiles}
-            />
-          </Box>
+          <LineItemDetail
+            row={row}
+            defaultMarkupPct={sheet.defaultMarkupPct}
+            sheetId={sheet._id}
+            tenderId={tenderId}
+            onUpdate={onUpdateRow}
+            onClose={onClose}
+            tenderFiles={tenderFiles}
+          />
         )}
       </DrawerContent>
     </Drawer>

--- a/client/src/components/TenderPricing/PricingBoardDrawer.tsx
+++ b/client/src/components/TenderPricing/PricingBoardDrawer.tsx
@@ -14,7 +14,7 @@ import { TenderPricingRow, TenderPricingSheet } from "./types";
 import { TenderFileItem } from "../Tender/types";
 import LineItemDetail from "./LineItemDetail";
 import StatusDot from "./StatusDot";
-import { LineItemStatus, STATUS_LABELS } from "./statusConstants";
+import { LineItemStatus, LINE_ITEM_STATUSES, STATUS_LABELS, STATUS_COLORS } from "./statusConstants";
 
 interface PricingBoardDrawerProps {
   row: TenderPricingRow | null;
@@ -42,17 +42,40 @@ const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
         {row && (
           <>
             <DrawerHeader px={4} py={3} borderBottom="1px solid" borderColor="gray.100">
-              <Flex align="center" justify="space-between" gap={2}>
-                <Flex align="center" gap={3} flex={1} minW={0}>
-                  <StatusDot status={status} onChange={(s) => onUpdateRow(row._id, { status: s })} />
-                  <Box flex={1} minW={0}>
-                    <Text fontSize="sm" fontWeight="semibold" noOfLines={1}>
-                      {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
-                    </Text>
-                    <Text fontSize="xs" color="gray.500" fontWeight="normal">{STATUS_LABELS[status]}</Text>
-                  </Box>
-                </Flex>
+              <Flex align="center" justify="space-between" gap={2} mb={2}>
+                <Text fontSize="sm" fontWeight="semibold" noOfLines={1} flex={1} minW={0}>
+                  {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
+                </Text>
                 <CloseButton size="sm" onClick={onClose} />
+              </Flex>
+              <Flex gap={2}>
+                {LINE_ITEM_STATUSES.map((s) => (
+                  <Flex
+                    key={s}
+                    align="center"
+                    gap={1.5}
+                    px={3}
+                    py={1.5}
+                    borderRadius="full"
+                    cursor="pointer"
+                    border="1px solid"
+                    borderColor={s === status ? STATUS_COLORS[s] : "gray.200"}
+                    bg={s === status ? `${STATUS_COLORS[s]}18` : "transparent"}
+                    _hover={{ borderColor: STATUS_COLORS[s] }}
+                    transition="all 0.15s"
+                    onClick={() => onUpdateRow(row._id, { status: s })}
+                  >
+                    <Box w="7px" h="7px" borderRadius="full" bg={STATUS_COLORS[s]} flexShrink={0} />
+                    <Text
+                      fontSize="xs"
+                      fontWeight={s === status ? "semibold" : "normal"}
+                      color={s === status ? "gray.800" : "gray.500"}
+                      whiteSpace="nowrap"
+                    >
+                      {STATUS_LABELS[s]}
+                    </Text>
+                  </Flex>
+                ))}
               </Flex>
             </DrawerHeader>
             <DrawerBody p={0} overflowY="auto">

--- a/client/src/components/TenderPricing/PricingBoardDrawer.tsx
+++ b/client/src/components/TenderPricing/PricingBoardDrawer.tsx
@@ -2,6 +2,11 @@ import React from "react";
 import {
   Box,
   CloseButton,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
   Flex,
   Text,
 } from "@chakra-ui/react";
@@ -28,68 +33,43 @@ const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
   onUpdateRow,
   tenderFiles,
 }) => {
-  const isOpen = !!row;
   const status = row ? ((row.status as LineItemStatus) ?? "not_started") : "not_started";
 
   return (
-    <Box
-      position="absolute"
-      bottom={0}
-      left={0}
-      right={0}
-      h="55%"
-      bg="white"
-      borderTop="1px solid"
-      borderColor="gray.200"
-      boxShadow="0 -4px 16px rgba(0,0,0,0.08)"
-      transform={isOpen ? "translateY(0)" : "translateY(100%)"}
-      transition="transform 0.25s ease"
-      display="flex"
-      flexDir="column"
-      overflow="hidden"
-      zIndex={10}
-    >
-      {row && (
-        <>
-          {/* Header with status */}
-          <Flex
-            px={4}
-            py={2}
-            align="center"
-            justify="space-between"
-            borderBottom="1px solid"
-            borderColor="gray.100"
-            flexShrink={0}
-            gap={2}
-            bg="gray.50"
-          >
-            <Flex align="center" gap={3} flex={1} minW={0}>
-              <StatusDot status={status} onChange={(s) => onUpdateRow(row._id, { status: s })} />
-              <Box flex={1} minW={0}>
-                <Text fontSize="sm" fontWeight="semibold" noOfLines={1}>
-                  {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
-                </Text>
-                <Text fontSize="xs" color="gray.500">{STATUS_LABELS[status]}</Text>
-              </Box>
-            </Flex>
-            <CloseButton size="sm" onClick={onClose} />
-          </Flex>
-
-          {/* Full LineItemDetail */}
-          <Box flex={1} overflowY="auto">
-            <LineItemDetail
-              row={row}
-              defaultMarkupPct={sheet.defaultMarkupPct}
-              sheetId={sheet._id}
-              tenderId={tenderId}
-              onUpdate={onUpdateRow}
-              onClose={onClose}
-              tenderFiles={tenderFiles}
-            />
-          </Box>
-        </>
-      )}
-    </Box>
+    <Drawer isOpen={!!row} onClose={onClose} placement="bottom" size="md">
+      <DrawerOverlay bg="blackAlpha.300" />
+      <DrawerContent maxH="60vh" borderTopRadius="xl">
+        {row && (
+          <>
+            <DrawerHeader px={4} py={3} borderBottom="1px solid" borderColor="gray.100">
+              <Flex align="center" justify="space-between" gap={2}>
+                <Flex align="center" gap={3} flex={1} minW={0}>
+                  <StatusDot status={status} onChange={(s) => onUpdateRow(row._id, { status: s })} />
+                  <Box flex={1} minW={0}>
+                    <Text fontSize="sm" fontWeight="semibold" noOfLines={1}>
+                      {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
+                    </Text>
+                    <Text fontSize="xs" color="gray.500" fontWeight="normal">{STATUS_LABELS[status]}</Text>
+                  </Box>
+                </Flex>
+                <CloseButton size="sm" onClick={onClose} />
+              </Flex>
+            </DrawerHeader>
+            <DrawerBody p={0} overflowY="auto">
+              <LineItemDetail
+                row={row}
+                defaultMarkupPct={sheet.defaultMarkupPct}
+                sheetId={sheet._id}
+                tenderId={tenderId}
+                onUpdate={onUpdateRow}
+                onClose={onClose}
+                tenderFiles={tenderFiles}
+              />
+            </DrawerBody>
+          </>
+        )}
+      </DrawerContent>
+    </Drawer>
   );
 };
 

--- a/client/src/components/TenderPricing/PricingBoardDrawer.tsx
+++ b/client/src/components/TenderPricing/PricingBoardDrawer.tsx
@@ -34,26 +34,23 @@ const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
 
   return (
     <Box
-      position="fixed"
-      right={0}
-      top={0}
-      bottom={0}
-      w="450px"
-      maxW="100vw"
+      borderTop="1px solid"
+      borderColor="gray.200"
       bg="white"
-      boxShadow="-4px 0 16px rgba(0,0,0,0.1)"
-      zIndex={20}
+      flexShrink={0}
+      maxH="50%"
       display="flex"
       flexDir="column"
+      overflow="hidden"
     >
       {/* Header with status */}
       <Flex
         px={4}
-        py={3}
+        py={2}
         align="center"
         justify="space-between"
         borderBottom="1px solid"
-        borderColor="gray.200"
+        borderColor="gray.100"
         flexShrink={0}
         gap={2}
       >

--- a/client/src/components/TenderPricing/PricingBoardDrawer.tsx
+++ b/client/src/components/TenderPricing/PricingBoardDrawer.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import {
+  Box,
+  CloseButton,
+  Divider,
+  Flex,
+  Text,
+} from "@chakra-ui/react";
+import { TenderPricingRow, TenderPricingSheet } from "./types";
+import { TenderFileItem } from "../Tender/types";
+import { computeRow, formatCurrency } from "./compute";
+import { EditableCell } from "./PricingRow";
+import StatusDot from "./StatusDot";
+import { LineItemStatus, STATUS_LABELS } from "./statusConstants";
+
+interface PricingBoardDrawerProps {
+  row: TenderPricingRow | null;
+  sheet: TenderPricingSheet;
+  tenderId: string;
+  onClose: () => void;
+  onUpdateRow: (rowId: string, data: Record<string, unknown>) => Promise<void>;
+  tenderFiles?: TenderFileItem[];
+}
+
+const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
+  row,
+  sheet,
+  onClose,
+  onUpdateRow,
+}) => {
+  if (!row) return null;
+
+  const status = (row.status as LineItemStatus) ?? "not_started";
+  const { effectiveMarkup, suggestedBidUP, lineItemTotal } = computeRow(row, sheet.defaultMarkupPct);
+  const costUP = (row.unitPrice ?? 0) + (row.extraUnitPrice ?? 0);
+
+  return (
+    <Box
+      position="fixed"
+      right={0}
+      top={0}
+      bottom={0}
+      w="400px"
+      maxW="100vw"
+      bg="white"
+      boxShadow="-4px 0 16px rgba(0,0,0,0.1)"
+      zIndex={20}
+      display="flex"
+      flexDir="column"
+      overflowY="auto"
+    >
+      {/* Header */}
+      <Flex px={4} py={3} align="center" justify="space-between" borderBottom="1px solid" borderColor="gray.200" flexShrink={0}>
+        <Flex align="center" gap={3}>
+          <StatusDot status={status} onChange={(s) => onUpdateRow(row._id, { status: s })} />
+          <Text fontSize="sm" fontWeight="semibold" noOfLines={1}>
+            {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
+          </Text>
+        </Flex>
+        <CloseButton size="sm" onClick={onClose} />
+      </Flex>
+
+      {/* Status label */}
+      <Box px={4} py={2} bg="gray.50" borderBottom="1px solid" borderColor="gray.100">
+        <Text fontSize="xs" color="gray.500">{STATUS_LABELS[status]}</Text>
+      </Box>
+
+      {/* Fields */}
+      <Box px={4} py={4} flex={1}>
+        <Box mb={4}>
+          <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+            Description
+          </Text>
+          <EditableCell
+            value={row.description}
+            onSave={(v) => onUpdateRow(row._id, { description: v })}
+            placeholder="Enter description"
+            wrap
+          />
+        </Box>
+
+        <Flex gap={4} mb={4}>
+          <Box flex={1}>
+            <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+              Quantity
+            </Text>
+            <EditableCell
+              value={row.quantity}
+              onSave={(v) => onUpdateRow(row._id, { quantity: parseFloat(v) || null })}
+              placeholder="—"
+            />
+          </Box>
+          <Box flex={1}>
+            <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+              Unit
+            </Text>
+            <EditableCell
+              value={row.unit}
+              onSave={(v) => onUpdateRow(row._id, { unit: v || null })}
+              placeholder="—"
+            />
+          </Box>
+        </Flex>
+
+        <Divider mb={4} />
+
+        <Flex gap={4} mb={4}>
+          <Box flex={1}>
+            <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+              Cost Unit Price
+            </Text>
+            <Text fontSize="sm" color={costUP > 0 ? "gray.800" : "gray.400"}>
+              {costUP > 0 ? `$${costUP.toFixed(2)}` : "—"}
+            </Text>
+          </Box>
+          <Box flex={1}>
+            <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+              Bid Unit Price
+            </Text>
+            <Text fontSize="sm" fontWeight="medium" color={suggestedBidUP > 0 ? "blue.700" : "gray.400"}>
+              {suggestedBidUP > 0 ? `$${suggestedBidUP.toFixed(2)}` : "—"}
+            </Text>
+          </Box>
+        </Flex>
+
+        <Box mb={4}>
+          <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+            Line Item Total
+          </Text>
+          <Text fontSize="md" fontWeight="semibold" color={lineItemTotal > 0 ? "gray.800" : "gray.400"}>
+            {lineItemTotal > 0 ? formatCurrency(lineItemTotal) : "—"}
+          </Text>
+        </Box>
+
+        <Divider mb={4} />
+
+        <Box mb={4}>
+          <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+            Notes
+          </Text>
+          <EditableCell
+            value={row.notes}
+            onSave={(v) => onUpdateRow(row._id, { notes: v || null })}
+            placeholder="Add notes..."
+            wrap
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default PricingBoardDrawer;

--- a/client/src/components/TenderPricing/PricingBoardDrawer.tsx
+++ b/client/src/components/TenderPricing/PricingBoardDrawer.tsx
@@ -30,9 +30,9 @@ const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
   return (
     <Drawer isOpen={!!row} onClose={onClose} placement="bottom" size="md">
       <DrawerOverlay bg="blackAlpha.300" />
-      <DrawerContent maxH="60vh" borderTopRadius="xl">
+      <DrawerContent maxH="60vh" borderTopRadius="xl" display="flex" flexDir="column">
         {row && (
-          <DrawerBody p={0} overflow="hidden">
+          <DrawerBody p={0} flex={1} display="flex" flexDir="column" overflow="hidden" minH={0}>
             <LineItemDetail
               row={row}
               defaultMarkupPct={sheet.defaultMarkupPct}

--- a/client/src/components/TenderPricing/PricingBoardDrawer.tsx
+++ b/client/src/components/TenderPricing/PricingBoardDrawer.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import {
   Box,
   Drawer,
-  DrawerBody,
   DrawerContent,
   DrawerOverlay,
 } from "@chakra-ui/react";
@@ -28,11 +27,11 @@ const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
   tenderFiles,
 }) => {
   return (
-    <Drawer isOpen={!!row} onClose={onClose} placement="bottom" size="md">
+    <Drawer isOpen={!!row} onClose={onClose} placement="bottom">
       <DrawerOverlay bg="blackAlpha.300" />
-      <DrawerContent maxH="60vh" borderTopRadius="xl" display="flex" flexDir="column">
+      <DrawerContent maxH="60vh" borderTopRadius="xl" overflow="hidden">
         {row && (
-          <DrawerBody p={0} flex={1} display="flex" flexDir="column" overflow="hidden" minH={0}>
+          <Box h="100%" overflow="hidden">
             <LineItemDetail
               row={row}
               defaultMarkupPct={sheet.defaultMarkupPct}
@@ -42,7 +41,7 @@ const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
               onClose={onClose}
               tenderFiles={tenderFiles}
             />
-          </DrawerBody>
+          </Box>
         )}
       </DrawerContent>
     </Drawer>

--- a/client/src/components/TenderPricing/PricingBoardDrawer.tsx
+++ b/client/src/components/TenderPricing/PricingBoardDrawer.tsx
@@ -1,20 +1,14 @@
 import React from "react";
 import {
   Box,
-  CloseButton,
   Drawer,
   DrawerBody,
   DrawerContent,
-  DrawerHeader,
   DrawerOverlay,
-  Flex,
-  Text,
 } from "@chakra-ui/react";
 import { TenderPricingRow, TenderPricingSheet } from "./types";
 import { TenderFileItem } from "../Tender/types";
 import LineItemDetail from "./LineItemDetail";
-import StatusDot from "./StatusDot";
-import { LineItemStatus, LINE_ITEM_STATUSES, STATUS_LABELS, STATUS_COLORS } from "./statusConstants";
 
 interface PricingBoardDrawerProps {
   row: TenderPricingRow | null;
@@ -33,63 +27,22 @@ const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
   onUpdateRow,
   tenderFiles,
 }) => {
-  const status = row ? ((row.status as LineItemStatus) ?? "not_started") : "not_started";
-
   return (
     <Drawer isOpen={!!row} onClose={onClose} placement="bottom" size="md">
       <DrawerOverlay bg="blackAlpha.300" />
       <DrawerContent maxH="60vh" borderTopRadius="xl">
         {row && (
-          <>
-            <DrawerHeader px={4} py={3} borderBottom="1px solid" borderColor="gray.100">
-              <Flex align="center" justify="space-between" gap={2} mb={2}>
-                <Text fontSize="sm" fontWeight="semibold" noOfLines={1} flex={1} minW={0}>
-                  {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
-                </Text>
-                <CloseButton size="sm" onClick={onClose} />
-              </Flex>
-              <Flex gap={2}>
-                {LINE_ITEM_STATUSES.map((s) => (
-                  <Flex
-                    key={s}
-                    align="center"
-                    gap={1.5}
-                    px={3}
-                    py={1.5}
-                    borderRadius="full"
-                    cursor="pointer"
-                    border="1px solid"
-                    borderColor={s === status ? STATUS_COLORS[s] : "gray.200"}
-                    bg={s === status ? `${STATUS_COLORS[s]}18` : "transparent"}
-                    _hover={{ borderColor: STATUS_COLORS[s] }}
-                    transition="all 0.15s"
-                    onClick={() => onUpdateRow(row._id, { status: s })}
-                  >
-                    <Box w="7px" h="7px" borderRadius="full" bg={STATUS_COLORS[s]} flexShrink={0} />
-                    <Text
-                      fontSize="xs"
-                      fontWeight={s === status ? "semibold" : "normal"}
-                      color={s === status ? "gray.800" : "gray.500"}
-                      whiteSpace="nowrap"
-                    >
-                      {STATUS_LABELS[s]}
-                    </Text>
-                  </Flex>
-                ))}
-              </Flex>
-            </DrawerHeader>
-            <DrawerBody p={0} overflowY="auto">
-              <LineItemDetail
-                row={row}
-                defaultMarkupPct={sheet.defaultMarkupPct}
-                sheetId={sheet._id}
-                tenderId={tenderId}
-                onUpdate={onUpdateRow}
-                onClose={onClose}
-                tenderFiles={tenderFiles}
-              />
-            </DrawerBody>
-          </>
+          <DrawerBody p={0} overflow="hidden">
+            <LineItemDetail
+              row={row}
+              defaultMarkupPct={sheet.defaultMarkupPct}
+              sheetId={sheet._id}
+              tenderId={tenderId}
+              onUpdate={onUpdateRow}
+              onClose={onClose}
+              tenderFiles={tenderFiles}
+            />
+          </DrawerBody>
         )}
       </DrawerContent>
     </Drawer>

--- a/client/src/components/TenderPricing/PricingRow.tsx
+++ b/client/src/components/TenderPricing/PricingRow.tsx
@@ -15,6 +15,8 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { TenderPricingRow, TenderPricingRowType } from "./types";
 import { computeRow, computeSubtotal, formatCurrency, formatMarkup } from "./compute";
+import StatusDot from "./StatusDot";
+import { LineItemStatus } from "./statusConstants";
 
 // ─── Inline editable cell ─────────────────────────────────────────────────────
 
@@ -276,6 +278,7 @@ export const SortableRow: React.FC<SortableRowProps> = ({
       defaultMarkupPct={defaultMarkupPct}
       isSelected={row._id === selectedRowId}
       sectionIndex={sectionIndex}
+      onUpdate={onUpdate}
       onDelete={onDelete}
       onSelect={onSelect}
       onDuplicate={onDuplicate}
@@ -369,6 +372,7 @@ const HeaderRow: React.FC<HeaderRowProps> = ({
       color={isSchedule ? "white" : "gray.800"}
     >
       <DragHandle {...dragHandleProps} />
+      <Td w="24px" px={1} />
       <Td px={1}>
         {isSchedule ? (
           <Text fontSize="xs" color="gray.300">
@@ -410,6 +414,7 @@ interface ItemRowProps {
   defaultMarkupPct: number;
   isSelected: boolean;
   sectionIndex: number;
+  onUpdate: (rowId: string, data: Record<string, unknown>) => void;
   onDelete: (rowId: string) => void;
   onSelect: (rowId: string) => void;
   onDuplicate: (rowId: string) => void;
@@ -423,6 +428,7 @@ const ItemRow: React.FC<ItemRowProps> = ({
   defaultMarkupPct,
   isSelected,
   sectionIndex,
+  onUpdate,
   onDelete,
   onSelect,
   onDuplicate,
@@ -447,6 +453,12 @@ const ItemRow: React.FC<ItemRowProps> = ({
       onClick={() => onSelect(row._id)}
     >
       <DragHandle {...(dragHandleProps as any)} />
+      <Td px={1} w="24px" onClick={(e) => e.stopPropagation()}>
+        <StatusDot
+          status={(row.status as LineItemStatus) ?? "not_started"}
+          onChange={(s) => onUpdate(row._id, { status: s })}
+        />
+      </Td>
       <Td px={2} whiteSpace="nowrap">
         <Text fontSize="sm" color={row.itemNumber ? "gray.800" : "gray.400"}>
           {row.itemNumber || "—"}

--- a/client/src/components/TenderPricing/PricingSheet.tsx
+++ b/client/src/components/TenderPricing/PricingSheet.tsx
@@ -54,6 +54,7 @@ const ROW_FIELDS = `
   rateBuildupSnapshot
   extraUnitPrice
   extraUnitPriceMemo
+  status
   docRefs {
     _id
     enrichedFileId

--- a/client/src/components/TenderPricing/PricingSheet.tsx
+++ b/client/src/components/TenderPricing/PricingSheet.tsx
@@ -36,6 +36,7 @@ import { computeSheetTotal, formatCurrency } from "./compute";
 import { SortableRow } from "./PricingRow";
 import ScheduleList from "./ScheduleList";
 import LineItemDetail from "./LineItemDetail";
+import PricingBoard from "./PricingBoard";
 
 // ─── GQL Mutations ────────────────────────────────────────────────────────────
 
@@ -167,9 +168,11 @@ interface PricingSheetProps {
   activeDocFile?: string;
   activeDocPage?: number;
   onDocRefClick?: (enrichedFileId: string, page: number) => void;
+  viewMode?: "list" | "board";
+  onViewModeChange?: (mode: "list" | "board") => void;
 }
 
-const PricingSheet: React.FC<PricingSheetProps> = ({ sheet, tenderId, onUpdate, tenderFiles, activeDocFile, activeDocPage, onDocRefClick }) => {
+const PricingSheet: React.FC<PricingSheetProps> = ({ sheet, tenderId, onUpdate, tenderFiles, activeDocFile, activeDocPage, onDocRefClick, viewMode, onViewModeChange }) => {
   const [markupDraft, setMarkupDraft] = useState(String(sheet.defaultMarkupPct));
   const [editingMarkup, setEditingMarkup] = useState(false);
 
@@ -388,6 +391,24 @@ const PricingSheet: React.FC<PricingSheetProps> = ({ sheet, tenderId, onUpdate, 
         </Flex>
 
         <Flex align="center" gap={4}>
+          {onViewModeChange && (
+            <ButtonGroup size="xs" isAttached variant="outline" mr={2}>
+              <Button
+                onClick={() => onViewModeChange("list")}
+                colorScheme={viewMode !== "board" ? "blue" : "gray"}
+                variant={viewMode !== "board" ? "solid" : "outline"}
+              >
+                List
+              </Button>
+              <Button
+                onClick={() => onViewModeChange("board")}
+                colorScheme={viewMode === "board" ? "blue" : "gray"}
+                variant={viewMode === "board" ? "solid" : "outline"}
+              >
+                Board
+              </Button>
+            </ButtonGroup>
+          )}
           <Flex align="center" gap={2}>
             <Text fontSize="sm" color="gray.600" whiteSpace="nowrap">
               Default Markup:
@@ -455,6 +476,14 @@ const PricingSheet: React.FC<PricingSheetProps> = ({ sheet, tenderId, onUpdate, 
             Add a Schedule, Group, or Line Item to get started.
           </Text>
         </Box>
+      ) : viewMode === "board" ? (
+        <PricingBoard
+          sheet={sheet}
+          tenderId={tenderId}
+          onUpdate={onUpdate}
+          onUpdateRow={handleUpdateRow}
+          tenderFiles={tenderFiles}
+        />
       ) : isDetailOpen ? (
         /* ── Split pane: schedule list + detail panel ─────────────────── */
         <Flex

--- a/client/src/components/TenderPricing/PricingSheet.tsx
+++ b/client/src/components/TenderPricing/PricingSheet.tsx
@@ -352,7 +352,7 @@ const PricingSheet: React.FC<PricingSheetProps> = ({ sheet, tenderId, onUpdate, 
   }, [isDetailOpen]);
 
   return (
-    <Box>
+    <Box flex={1} display="flex" flexDir="column" minH={0} h={viewMode === "board" ? "100%" : undefined}>
       {/* ── Toolbar ──────────────────────────────────────────────────────── */}
       <Flex align="center" justify="space-between" mb={4} wrap="wrap" gap={3}>
         <Flex align="center" gap={2}>

--- a/client/src/components/TenderPricing/PricingSheet.tsx
+++ b/client/src/components/TenderPricing/PricingSheet.tsx
@@ -500,6 +500,7 @@ const PricingSheet: React.FC<PricingSheetProps> = ({ sheet, tenderId, onUpdate, 
             <Thead>
               <Tr bg="gray.50">
                 <Th w="28px" px={1} />
+                <Th w="24px" px={1} />
                 <Th whiteSpace="nowrap" w="60px">#</Th>
                 <Th>Description</Th>
                 <Th isNumeric whiteSpace="nowrap" w="60px">Qty</Th>

--- a/client/src/components/TenderPricing/PricingSheet.tsx
+++ b/client/src/components/TenderPricing/PricingSheet.tsx
@@ -50,8 +50,6 @@ const ROW_FIELDS = `
   unit
   unitPrice
   notes
-  calculatorType
-  calculatorInputsJson
   markupOverride
   rateBuildupSnapshot
   extraUnitPrice

--- a/client/src/components/TenderPricing/StatusDot.tsx
+++ b/client/src/components/TenderPricing/StatusDot.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import {
+  Box,
+  Flex,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react";
+import {
+  LineItemStatus,
+  LINE_ITEM_STATUSES,
+  STATUS_COLORS,
+  STATUS_LABELS,
+} from "./statusConstants";
+
+interface StatusDotProps {
+  status: LineItemStatus;
+  onChange: (status: LineItemStatus) => void;
+}
+
+const StatusDot: React.FC<StatusDotProps> = ({ status, onChange }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  return (
+    <Popover isOpen={isOpen} onClose={onClose} placement="bottom-start" isLazy>
+      <PopoverTrigger>
+        <Box
+          as="button"
+          w="10px"
+          h="10px"
+          borderRadius="full"
+          bg={STATUS_COLORS[status]}
+          flexShrink={0}
+          cursor="pointer"
+          _hover={{ transform: "scale(1.3)" }}
+          transition="transform 0.1s"
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+            onOpen();
+          }}
+          title={STATUS_LABELS[status]}
+        />
+      </PopoverTrigger>
+      <PopoverContent w="180px" shadow="lg" border="1px solid" borderColor="gray.200">
+        <PopoverBody p={1}>
+          {LINE_ITEM_STATUSES.map((s) => (
+            <Flex
+              key={s}
+              align="center"
+              gap={2}
+              px={2}
+              py={1.5}
+              cursor="pointer"
+              borderRadius="sm"
+              bg={s === status ? "gray.100" : "transparent"}
+              _hover={{ bg: "gray.50" }}
+              onClick={(e) => {
+                e.stopPropagation();
+                onChange(s);
+                onClose();
+              }}
+            >
+              <Box
+                w="8px"
+                h="8px"
+                borderRadius="full"
+                bg={STATUS_COLORS[s]}
+                flexShrink={0}
+              />
+              <Text fontSize="xs" fontWeight={s === status ? "semibold" : "normal"}>
+                {STATUS_LABELS[s]}
+              </Text>
+            </Flex>
+          ))}
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default StatusDot;

--- a/client/src/components/TenderPricing/statusConstants.ts
+++ b/client/src/components/TenderPricing/statusConstants.ts
@@ -1,0 +1,29 @@
+export type LineItemStatus = "not_started" | "in_progress" | "review" | "approved";
+
+export const LINE_ITEM_STATUSES: LineItemStatus[] = [
+  "not_started",
+  "in_progress",
+  "review",
+  "approved",
+];
+
+export const STATUS_COLORS: Record<LineItemStatus, string> = {
+  not_started: "#94a3b8",
+  in_progress: "#3b82f6",
+  review: "#ca8a04",
+  approved: "#16a34a",
+};
+
+export const STATUS_BG: Record<LineItemStatus, string> = {
+  not_started: "gray.50",
+  in_progress: "blue.50",
+  review: "yellow.50",
+  approved: "green.50",
+};
+
+export const STATUS_LABELS: Record<LineItemStatus, string> = {
+  not_started: "Not Started",
+  in_progress: "In Progress",
+  review: "Ready for Review",
+  approved: "Approved",
+};

--- a/client/src/components/TenderPricing/types.ts
+++ b/client/src/components/TenderPricing/types.ts
@@ -23,8 +23,6 @@ export interface TenderPricingRow {
   markupOverride?: number | null;
   unitPrice?: number | null;
   notes?: string | null;
-  calculatorType?: string | null;
-  calculatorInputsJson?: string | null;
   rateBuildupSnapshot?: string | null;
   extraUnitPrice?: number | null;
   extraUnitPriceMemo?: string | null;

--- a/client/src/components/TenderPricing/types.ts
+++ b/client/src/components/TenderPricing/types.ts
@@ -27,6 +27,7 @@ export interface TenderPricingRow {
   extraUnitPrice?: number | null;
   extraUnitPriceMemo?: string | null;
   docRefs?: DocRef[] | null;
+  status?: string | null;
 }
 
 export interface TenderPricingSheet {

--- a/client/src/pages/tender/[id]/index.tsx
+++ b/client/src/pages/tender/[id]/index.tsx
@@ -501,10 +501,13 @@ const TenderDetailPage = () => {
             <Box
               flex={1}
               minW={0}
-              overflowY="auto"
-              p={4}
+              overflowY={pricingViewMode === "board" ? "hidden" : "auto"}
+              overflow={pricingViewMode === "board" ? "hidden" : undefined}
+              p={pricingViewMode === "board" ? 0 : 4}
               borderRight={panelState === "open" ? "1px solid" : undefined}
               borderColor="gray.200"
+              display="flex"
+              flexDir="column"
             >
               {!initialized ? (
                 <Spinner />

--- a/client/src/pages/tender/[id]/index.tsx
+++ b/client/src/pages/tender/[id]/index.tsx
@@ -684,6 +684,7 @@ const TenderDetailPage = () => {
                   <TenderReviewTab
                     tenderId={tenderId}
                     currentUserId={currentUserId}
+                    sheet={sheet}
                   />
                 )}
               </Box>

--- a/client/src/pages/tender/[id]/index.tsx
+++ b/client/src/pages/tender/[id]/index.tsx
@@ -28,7 +28,7 @@ import { TenderPricingSheet } from "../../../components/TenderPricing/types";
 import { TenderDetail, TenderFileItem } from "../../../components/Tender/types";
 import { UserRoles } from "../../../generated/graphql";
 import { navbarHeight } from "../../../constants/styles";
-import { localStorageTokenKey } from "../../../contexts/Auth";
+import { localStorageTokenKey, useAuth } from "../../../contexts/Auth";
 import ChatDrawer from "../../../components/Chat/ChatDrawer";
 import TenderMobileLayout from "../../../components/Tender/TenderMobileLayout";
 
@@ -265,6 +265,8 @@ const TenderDetailPage = () => {
   const router = useRouter();
   const { id } = router.query;
   const tenderId = typeof id === "string" ? id : "";
+  const { state: authState } = useAuth();
+  const currentUserId = authState.user?._id;
 
   const [sheet, setSheet] = useState<TenderPricingSheet | null>(null);
   const [initialized, setInitialized] = useState(false);
@@ -673,7 +675,7 @@ const TenderDetailPage = () => {
                 {rightTab === "review" && (
                   <TenderReviewTab
                     tenderId={tenderId}
-                    currentUserId={undefined}
+                    currentUserId={currentUserId}
                   />
                 )}
               </Box>

--- a/client/src/pages/tender/[id]/index.tsx
+++ b/client/src/pages/tender/[id]/index.tsx
@@ -60,6 +60,7 @@ const SHEET_QUERY = gql`
         rateBuildupSnapshot
         extraUnitPrice
         extraUnitPriceMemo
+        status
         docRefs {
           _id
           enrichedFileId
@@ -142,6 +143,7 @@ const CREATE_SHEET = gql`
         rateBuildupSnapshot
         extraUnitPrice
         extraUnitPriceMemo
+        status
       }
     }
   }

--- a/client/src/pages/tender/[id]/index.tsx
+++ b/client/src/pages/tender/[id]/index.tsx
@@ -272,6 +272,7 @@ const TenderDetailPage = () => {
 
   const [sheet, setSheet] = useState<TenderPricingSheet | null>(null);
   const [initialized, setInitialized] = useState(false);
+  const [pricingViewMode, setPricingViewMode] = useState<"list" | "board">("list");
   const [rightTab, setRightTab] = useState<RightTab>("documents");
   const [panelState, setPanelState] = useState<PanelState>("open");
   const [chatOpen, setChatOpen] = useState(false);
@@ -516,6 +517,8 @@ const TenderDetailPage = () => {
                   activeDocFile={selectedFile?._id}
                   activeDocPage={selectedFilePage}
                   onDocRefClick={handleDocRefClick}
+                  viewMode={pricingViewMode}
+                  onViewModeChange={setPricingViewMode}
                 />
               ) : (
                 <Text color="gray.500">Unable to load pricing sheet.</Text>

--- a/client/src/pages/tender/[id]/index.tsx
+++ b/client/src/pages/tender/[id]/index.tsx
@@ -23,6 +23,7 @@ import TenderOverview from "../../../components/Tender/TenderOverview";
 import TenderSummaryTab from "../../../components/Tender/TenderSummaryTab";
 import TenderNotesTab from "../../../components/Tender/TenderNotesTab";
 import TenderDocuments from "../../../components/Tender/TenderDocuments";
+import TenderReviewTab from "../../../components/Tender/TenderReviewTab";
 import { TenderPricingSheet } from "../../../components/TenderPricing/types";
 import { TenderDetail, TenderFileItem } from "../../../components/Tender/types";
 import { UserRoles } from "../../../generated/graphql";
@@ -157,7 +158,7 @@ const TENDER_SUGGESTIONS = [
 
 // ─── Panel tab types ──────────────────────────────────────────────────────────
 
-type RightTab = "job" | "documents" | "notes" | "summary";
+type RightTab = "job" | "documents" | "notes" | "summary" | "review";
 type PanelState = "open" | "hidden" | "fullscreen";
 
 // ─── File URL helper ──────────────────────────────────────────────────────────
@@ -436,6 +437,7 @@ const TenderDetailPage = () => {
       label: `Notes${tender && tender.notes.length > 0 ? ` (${tender.notes.length})` : ""}`,
     },
     { key: "summary", label: "Summary" },
+    { key: "review", label: "Review" },
   ];
 
   return (
@@ -666,6 +668,13 @@ const TenderDetailPage = () => {
                   <Flex h="100%" align="center" justify="center">
                     <Spinner />
                   </Flex>
+                )}
+
+                {rightTab === "review" && (
+                  <TenderReviewTab
+                    tenderId={tenderId}
+                    currentUserId={undefined}
+                  />
                 )}
               </Box>
             </Flex>

--- a/client/src/pages/tender/[id]/index.tsx
+++ b/client/src/pages/tender/[id]/index.tsx
@@ -55,8 +55,6 @@ const SHEET_QUERY = gql`
         unit
         unitPrice
         notes
-        calculatorType
-        calculatorInputsJson
         markupOverride
         rateBuildupSnapshot
         extraUnitPrice
@@ -139,8 +137,6 @@ const CREATE_SHEET = gql`
         unit
         unitPrice
         notes
-        calculatorType
-        calculatorInputsJson
         markupOverride
         rateBuildupSnapshot
         extraUnitPrice

--- a/docs/superpowers/plans/2026-04-09-line-item-status-kanban.md
+++ b/docs/superpowers/plans/2026-04-09-line-item-status-kanban.md
@@ -1,0 +1,1157 @@
+# Line Item Status & Kanban Board Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-line-item status tracking with a Kanban board view as an alternative to the existing list view on the tender pricing sheet.
+
+**Architecture:** A `status` field on `TenderPricingRowClass` stores the estimating stage (not_started → in_progress → review → approved). The existing `tenderPricingRowUpdate` mutation handles status changes. A new `PricingBoard` component renders a weighted 4-column Kanban. Status changes generate descriptive audit events via a `statusTo` field on `TenderAuditEventClass`.
+
+**Tech Stack:** Typegoose + Type-GraphQL (server), Apollo Client + Chakra UI (client), ReactFlow not involved.
+
+> **Note on tests:** Write test files as specified but do NOT run `npm run test` during implementation — skip all test-execution steps per project convention.
+
+---
+
+## File Map
+
+**New — client:**
+- `client/src/components/TenderPricing/statusConstants.ts` — shared status types, colors, labels
+- `client/src/components/TenderPricing/StatusDot.tsx` — clickable dot + popover component
+- `client/src/components/TenderPricing/PricingBoard.tsx` — Kanban board view
+- `client/src/components/TenderPricing/PricingBoardDrawer.tsx` — detail drawer for board card clicks
+
+**Modified — server:**
+- `server/src/models/TenderPricingSheet/schema/index.ts` — add `status` to row schema
+- `server/src/typescript/tenderPricingSheet.ts` — add `status` to `ITenderPricingRowUpdate`
+- `server/src/models/TenderPricingSheet/class/update.ts` — add `status` to `updateRow` and `duplicateRow`
+- `server/src/graphql/resolvers/tenderPricingSheet/mutations.ts` — add `status` to GQL input
+- `server/src/typescript/tenderReview.ts` — add `"status"` to tracked fields, add `statusTo` to event interface
+- `server/src/models/TenderReview/schema/index.ts` — add `statusTo` field
+- `server/src/models/TenderReview/class/update.ts` — accept `statusTo`
+- `server/src/graphql/resolvers/tenderPricingSheet/index.ts` — pass `statusTo` in audit event
+
+**Modified — client:**
+- `client/src/components/TenderPricing/types.ts` — add `status` to row type
+- `client/src/components/TenderPricing/PricingSheet.tsx` — add `status` to GQL fragment
+- `client/src/components/TenderPricing/PricingRow.tsx` — add StatusDot to ItemRow
+- `client/src/pages/tender/[id]/index.tsx` — add view toggle + conditional PricingBoard rendering, add `status` to GQL fragments
+- `client/src/components/Tender/TenderMobilePricingTab.tsx` — add `status` to GQL fragment, add view toggle
+- `client/src/components/Tender/TenderReviewTab.tsx` — update `buildActionLabel` for status events
+
+---
+
+### Task 1: Server — add `status` field to pricing row
+
+**Files:**
+- Modify: `server/src/models/TenderPricingSheet/schema/index.ts`
+- Modify: `server/src/typescript/tenderPricingSheet.ts`
+- Modify: `server/src/models/TenderPricingSheet/class/update.ts`
+- Modify: `server/src/graphql/resolvers/tenderPricingSheet/mutations.ts`
+
+- [ ] **Step 1: Add `status` prop to `TenderPricingRowClass` in schema**
+
+In `server/src/models/TenderPricingSheet/schema/index.ts`, add after the `docRefs` field (around line 94):
+
+```typescript
+  @Field(() => String, { nullable: true })
+  @prop({ trim: true, default: "not_started" })
+  public status?: string;
+```
+
+- [ ] **Step 2: Add `status` to `ITenderPricingRowUpdate` in TypeScript types**
+
+In `server/src/typescript/tenderPricingSheet.ts`, add to the `ITenderPricingRowUpdate` interface:
+
+```typescript
+  status?: string;
+```
+
+- [ ] **Step 3: Add `status` to `updateRow` in update class**
+
+In `server/src/models/TenderPricingSheet/class/update.ts`, add to the `updateRow` function alongside the other field assignments:
+
+```typescript
+  if (data.status !== undefined) row.status = data.status;
+```
+
+Also add `status` to the `duplicateRow` function's `newRow` object:
+
+```typescript
+  status: src.status,
+```
+
+- [ ] **Step 4: Add `status` to GQL input type**
+
+In `server/src/graphql/resolvers/tenderPricingSheet/mutations.ts`, add to `TenderPricingRowUpdateData`:
+
+```typescript
+  @Field(() => String, { nullable: true })
+  public status?: string;
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/models/TenderPricingSheet/schema/index.ts \
+        server/src/typescript/tenderPricingSheet.ts \
+        server/src/models/TenderPricingSheet/class/update.ts \
+        server/src/graphql/resolvers/tenderPricingSheet/mutations.ts
+git commit -m "feat: add status field to TenderPricingRow"
+```
+
+---
+
+### Task 2: Server — audit trail statusTo support
+
+**Files:**
+- Modify: `server/src/typescript/tenderReview.ts`
+- Modify: `server/src/models/TenderReview/schema/index.ts`
+- Modify: `server/src/models/TenderReview/class/update.ts`
+- Modify: `server/src/graphql/resolvers/tenderPricingSheet/index.ts`
+
+- [ ] **Step 1: Add `"status"` to `TRACKED_ROW_FIELDS` and `statusTo` to event interface**
+
+In `server/src/typescript/tenderReview.ts`, add `"status"` to the `TRACKED_ROW_FIELDS` array:
+
+```typescript
+export const TRACKED_ROW_FIELDS: string[] = [
+  "quantity",
+  "unit",
+  "unitPrice",
+  "markupOverride",
+  "rateBuildupSnapshot",
+  "extraUnitPrice",
+  "extraUnitPriceMemo",
+  "description",
+  "itemNumber",
+  "notes",
+  "status",
+];
+```
+
+Add `statusTo` to `ITenderAuditEventCreate`:
+
+```typescript
+export interface ITenderAuditEventCreate {
+  rowId: string;
+  rowDescription: string;
+  action: TenderAuditAction;
+  changedFields: string[];
+  changedBy: string;
+  statusTo?: string;
+}
+```
+
+- [ ] **Step 2: Add `statusTo` field to `TenderAuditEventClass` schema**
+
+In `server/src/models/TenderReview/schema/index.ts`, add after the `changedAt` field on `TenderAuditEventClass`:
+
+```typescript
+  @Field(() => String, { nullable: true })
+  @prop({ trim: true })
+  public statusTo?: string;
+```
+
+- [ ] **Step 3: Accept `statusTo` in `addAuditEvent` update function**
+
+In `server/src/models/TenderReview/class/update.ts`, update the `addAuditEvent` function to include `statusTo`:
+
+```typescript
+const addAuditEvent = (
+  review: TenderReviewDocument,
+  event: ITenderAuditEventCreate
+): TenderReviewDocument => {
+  (review.auditLog as any).push({
+    _id: new Types.ObjectId(),
+    rowId: new Types.ObjectId(event.rowId),
+    rowDescription: event.rowDescription,
+    action: event.action,
+    changedFields: event.changedFields,
+    changedBy: new Types.ObjectId(event.changedBy),
+    changedAt: new Date(),
+    ...(event.statusTo ? { statusTo: event.statusTo } : {}),
+  });
+  review.updatedAt = new Date();
+  return review;
+};
+```
+
+- [ ] **Step 4: Pass `statusTo` in the `tenderPricingRowUpdate` resolver**
+
+In `server/src/graphql/resolvers/tenderPricingSheet/index.ts`, update the audit event creation inside `tenderPricingRowUpdate` to include `statusTo`:
+
+Replace:
+```typescript
+        await (TenderReview as any).addAuditEvent((sheet!.tender as any).toString(), {
+          rowId: rowId.toString(),
+          rowDescription: row?.description ?? "",
+          action: "row_updated",
+          changedFields,
+          changedBy: ctx.user._id.toString(),
+        });
+```
+
+With:
+```typescript
+        await (TenderReview as any).addAuditEvent((sheet!.tender as any).toString(), {
+          rowId: rowId.toString(),
+          rowDescription: row?.description ?? "",
+          action: "row_updated",
+          changedFields,
+          changedBy: ctx.user._id.toString(),
+          ...(data.status ? { statusTo: data.status } : {}),
+        });
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/typescript/tenderReview.ts \
+        server/src/models/TenderReview/schema/index.ts \
+        server/src/models/TenderReview/class/update.ts \
+        server/src/graphql/resolvers/tenderPricingSheet/index.ts
+git commit -m "feat: audit trail statusTo support for descriptive status change events"
+```
+
+---
+
+### Task 3: Client — status constants + StatusDot component
+
+**Files:**
+- Create: `client/src/components/TenderPricing/statusConstants.ts`
+- Create: `client/src/components/TenderPricing/StatusDot.tsx`
+
+- [ ] **Step 1: Create `statusConstants.ts`**
+
+```typescript
+export type LineItemStatus = "not_started" | "in_progress" | "review" | "approved";
+
+export const LINE_ITEM_STATUSES: LineItemStatus[] = [
+  "not_started",
+  "in_progress",
+  "review",
+  "approved",
+];
+
+export const STATUS_COLORS: Record<LineItemStatus, string> = {
+  not_started: "#94a3b8",
+  in_progress: "#3b82f6",
+  review: "#ca8a04",
+  approved: "#16a34a",
+};
+
+export const STATUS_BG: Record<LineItemStatus, string> = {
+  not_started: "gray.50",
+  in_progress: "blue.50",
+  review: "yellow.50",
+  approved: "green.50",
+};
+
+export const STATUS_LABELS: Record<LineItemStatus, string> = {
+  not_started: "Not Started",
+  in_progress: "In Progress",
+  review: "Ready for Review",
+  approved: "Approved",
+};
+```
+
+- [ ] **Step 2: Create `StatusDot.tsx`**
+
+```tsx
+import React from "react";
+import {
+  Box,
+  Flex,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react";
+import {
+  LineItemStatus,
+  LINE_ITEM_STATUSES,
+  STATUS_COLORS,
+  STATUS_LABELS,
+} from "./statusConstants";
+
+interface StatusDotProps {
+  status: LineItemStatus;
+  onChange: (status: LineItemStatus) => void;
+}
+
+const StatusDot: React.FC<StatusDotProps> = ({ status, onChange }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  return (
+    <Popover isOpen={isOpen} onClose={onClose} placement="bottom-start" isLazy>
+      <PopoverTrigger>
+        <Box
+          as="button"
+          w="10px"
+          h="10px"
+          borderRadius="full"
+          bg={STATUS_COLORS[status]}
+          flexShrink={0}
+          cursor="pointer"
+          _hover={{ transform: "scale(1.3)" }}
+          transition="transform 0.1s"
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+            onOpen();
+          }}
+          title={STATUS_LABELS[status]}
+        />
+      </PopoverTrigger>
+      <PopoverContent w="180px" shadow="lg" border="1px solid" borderColor="gray.200">
+        <PopoverBody p={1}>
+          {LINE_ITEM_STATUSES.map((s) => (
+            <Flex
+              key={s}
+              align="center"
+              gap={2}
+              px={2}
+              py={1.5}
+              cursor="pointer"
+              borderRadius="sm"
+              bg={s === status ? "gray.100" : "transparent"}
+              _hover={{ bg: "gray.50" }}
+              onClick={(e) => {
+                e.stopPropagation();
+                onChange(s);
+                onClose();
+              }}
+            >
+              <Box
+                w="8px"
+                h="8px"
+                borderRadius="full"
+                bg={STATUS_COLORS[s]}
+                flexShrink={0}
+              />
+              <Text fontSize="xs" fontWeight={s === status ? "semibold" : "normal"}>
+                {STATUS_LABELS[s]}
+              </Text>
+            </Flex>
+          ))}
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default StatusDot;
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/components/TenderPricing/statusConstants.ts \
+        client/src/components/TenderPricing/StatusDot.tsx
+git commit -m "feat: status constants + StatusDot popover component"
+```
+
+---
+
+### Task 4: Client — add status to types + GQL fragments
+
+**Files:**
+- Modify: `client/src/components/TenderPricing/types.ts`
+- Modify: `client/src/components/TenderPricing/PricingSheet.tsx`
+- Modify: `client/src/pages/tender/[id]/index.tsx`
+- Modify: `client/src/components/Tender/TenderMobilePricingTab.tsx`
+
+- [ ] **Step 1: Add `status` to `TenderPricingRow` type**
+
+In `client/src/components/TenderPricing/types.ts`, add after `docRefs`:
+
+```typescript
+  status?: string | null;
+```
+
+- [ ] **Step 2: Add `status` to `ROW_FIELDS` fragment in `PricingSheet.tsx`**
+
+In `client/src/components/TenderPricing/PricingSheet.tsx`, add `status` to the `ROW_FIELDS` template string (after `extraUnitPriceMemo`):
+
+```
+  status
+```
+
+- [ ] **Step 3: Add `status` to both GQL fragments in `client/src/pages/tender/[id]/index.tsx`**
+
+Add `status` to the `SHEET_QUERY` rows fragment and the `CREATE_SHEET` rows fragment (same location as other row fields like `extraUnitPriceMemo`).
+
+- [ ] **Step 4: Add `status` to GQL fragment in `TenderMobilePricingTab.tsx`**
+
+Add `status` to the `ROW_FIELDS` template string.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/TenderPricing/types.ts \
+        client/src/components/TenderPricing/PricingSheet.tsx \
+        "client/src/pages/tender/[id]/index.tsx" \
+        client/src/components/Tender/TenderMobilePricingTab.tsx
+git commit -m "feat: add status field to client types and GQL fragments"
+```
+
+---
+
+### Task 5: Client — add StatusDot to ItemRow in PricingRow
+
+**Files:**
+- Modify: `client/src/components/TenderPricing/PricingRow.tsx`
+
+- [ ] **Step 1: Add StatusDot to the ItemRow component**
+
+Import StatusDot and LineItemStatus at the top of `PricingRow.tsx`:
+
+```typescript
+import StatusDot from "./StatusDot";
+import { LineItemStatus } from "./statusConstants";
+```
+
+Add `onUpdate` to `ItemRowProps` (it's already on `SortableRowProps` and passed through — the `ItemRow` needs it to fire status changes):
+
+In `ItemRowProps` interface, add:
+```typescript
+  onUpdate: (rowId: string, data: Record<string, unknown>) => void;
+```
+
+Pass `onUpdate` through from `SortableRow` to `ItemRow`.
+
+In the `ItemRow` component's render, add the StatusDot as the first cell content, before the item number `<Td>`. Insert a new `<Td>` after the `DragHandle`:
+
+```tsx
+      <Td px={1} w="24px" onClick={(e) => e.stopPropagation()}>
+        <StatusDot
+          status={(row.status as LineItemStatus) ?? "not_started"}
+          onChange={(s) => onUpdate(row._id, { status: s })}
+        />
+      </Td>
+```
+
+Also add a corresponding `<Th>` in the table header (in `PricingSheet.tsx` where the header row is rendered) — a thin empty header for the status column.
+
+- [ ] **Step 2: Add status column header to the `<Thead>` in PricingSheet.tsx**
+
+In `PricingSheet.tsx`, find the `<Thead>` row and add an empty `<Th w="24px" px={1} />` after the drag handle header column.
+
+- [ ] **Step 3: Add an empty `<Td>` in `HeaderRow` for Schedule/Group rows**
+
+In `PricingRow.tsx`, in the `HeaderRow` component, add an empty `<Td w="24px" px={1} />` after the `DragHandle` to keep column alignment.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/components/TenderPricing/PricingRow.tsx \
+        client/src/components/TenderPricing/PricingSheet.tsx
+git commit -m "feat: add StatusDot to pricing row items in list view"
+```
+
+---
+
+### Task 6: Client — PricingBoard component
+
+**Files:**
+- Create: `client/src/components/TenderPricing/PricingBoard.tsx`
+
+- [ ] **Step 1: Create `PricingBoard.tsx`**
+
+```tsx
+import React, { useMemo, useState } from "react";
+import {
+  Box,
+  Flex,
+  Select,
+  Text,
+} from "@chakra-ui/react";
+import {
+  TenderPricingSheet,
+  TenderPricingRow,
+  TenderPricingRowType,
+} from "./types";
+import { TenderFileItem } from "../Tender/types";
+import { computeRow, formatCurrency } from "./compute";
+import {
+  LineItemStatus,
+  LINE_ITEM_STATUSES,
+  STATUS_COLORS,
+  STATUS_BG,
+  STATUS_LABELS,
+} from "./statusConstants";
+import PricingBoardDrawer from "./PricingBoardDrawer";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface PricingBoardProps {
+  sheet: TenderPricingSheet;
+  tenderId: string;
+  onUpdate: (updated: TenderPricingSheet) => void;
+  onUpdateRow: (rowId: string, data: Record<string, unknown>) => Promise<void>;
+  tenderFiles?: TenderFileItem[];
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function getScheduleForRow(
+  row: TenderPricingRow,
+  rows: TenderPricingRow[]
+): TenderPricingRow | null {
+  const idx = rows.indexOf(row);
+  for (let i = idx - 1; i >= 0; i--) {
+    if (rows[i].type === TenderPricingRowType.Schedule) return rows[i];
+  }
+  return null;
+}
+
+const COLUMN_FLEX: Record<LineItemStatus, number> = {
+  not_started: 2,
+  in_progress: 1,
+  review: 1,
+  approved: 1,
+};
+
+// ─── Card ────────────────────────────────────────────────────────────────────
+
+const BoardCard: React.FC<{
+  row: TenderPricingRow;
+  defaultMarkupPct: number;
+  scheduleName?: string;
+  onClick: () => void;
+}> = ({ row, defaultMarkupPct, scheduleName, onClick }) => {
+  const { lineItemTotal } = computeRow(row, defaultMarkupPct);
+
+  return (
+    <Box
+      bg="white"
+      border="1px solid"
+      borderColor="gray.200"
+      borderRadius="md"
+      px={3}
+      py={2}
+      mb={2}
+      cursor="pointer"
+      _hover={{ shadow: "sm", borderColor: "gray.300" }}
+      onClick={onClick}
+    >
+      <Flex justify="space-between" align="flex-start" gap={2}>
+        <Box flex={1} minW={0}>
+          <Text fontSize="xs" fontWeight="semibold" color="gray.800" noOfLines={1}>
+            {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
+          </Text>
+          <Text fontSize="xs" color="gray.500" mt={0.5}>
+            {row.quantity != null ? `${row.quantity} ${row.unit ?? ""}` : "No qty"}
+          </Text>
+        </Box>
+        <Text fontSize="xs" fontWeight="medium" color={lineItemTotal > 0 ? "gray.700" : "gray.400"} flexShrink={0}>
+          {lineItemTotal > 0 ? formatCurrency(lineItemTotal) : "—"}
+        </Text>
+      </Flex>
+      {scheduleName && (
+        <Text fontSize="9px" color="gray.400" mt={1} noOfLines={1}>{scheduleName}</Text>
+      )}
+    </Box>
+  );
+};
+
+// ─── Column ──────────────────────────────────────────────────────────────────
+
+const BoardColumn: React.FC<{
+  status: LineItemStatus;
+  rows: TenderPricingRow[];
+  allRows: TenderPricingRow[];
+  defaultMarkupPct: number;
+  onCardClick: (row: TenderPricingRow) => void;
+}> = ({ status, rows, allRows, defaultMarkupPct, onCardClick }) => (
+  <Flex
+    direction="column"
+    flex={COLUMN_FLEX[status]}
+    bg={STATUS_BG[status]}
+    borderRadius="lg"
+    overflow="hidden"
+    minW={0}
+  >
+    <Flex
+      px={3}
+      py={2}
+      align="center"
+      gap={2}
+      flexShrink={0}
+    >
+      <Box w="8px" h="8px" borderRadius="full" bg={STATUS_COLORS[status]} flexShrink={0} />
+      <Text
+        fontSize="10px"
+        fontWeight="semibold"
+        textTransform="uppercase"
+        letterSpacing="wide"
+        color="gray.600"
+      >
+        {STATUS_LABELS[status]}
+      </Text>
+      <Box
+        bg="gray.200"
+        borderRadius="full"
+        px={1.5}
+        py={0}
+        fontSize="10px"
+        fontWeight="semibold"
+        color="gray.600"
+      >
+        {rows.length}
+      </Box>
+    </Flex>
+    <Box flex={1} overflowY="auto" px={2} pb={2}>
+      {rows.map((row) => {
+        const sched = getScheduleForRow(row, allRows);
+        return (
+          <BoardCard
+            key={row._id}
+            row={row}
+            defaultMarkupPct={defaultMarkupPct}
+            scheduleName={sched?.description}
+            onClick={() => onCardClick(row)}
+          />
+        );
+      })}
+    </Box>
+  </Flex>
+);
+
+// ─── Board ───────────────────────────────────────────────────────────────────
+
+const PricingBoard: React.FC<PricingBoardProps> = ({
+  sheet,
+  tenderId,
+  onUpdate,
+  onUpdateRow,
+  tenderFiles,
+}) => {
+  const [selectedRow, setSelectedRow] = useState<TenderPricingRow | null>(null);
+  const [scheduleFilter, setScheduleFilter] = useState<string>("all");
+
+  const schedules = useMemo(
+    () => sheet.rows.filter((r) => r.type === TenderPricingRowType.Schedule),
+    [sheet.rows]
+  );
+
+  const items = useMemo(() => {
+    let rows = sheet.rows.filter((r) => r.type === TenderPricingRowType.Item);
+    if (scheduleFilter !== "all") {
+      const schedIdx = sheet.rows.findIndex((r) => r._id === scheduleFilter);
+      if (schedIdx >= 0) {
+        const nextSchedIdx = sheet.rows.findIndex(
+          (r, i) => i > schedIdx && r.type === TenderPricingRowType.Schedule
+        );
+        const endIdx = nextSchedIdx >= 0 ? nextSchedIdx : sheet.rows.length;
+        const schedRowIds = new Set(
+          sheet.rows.slice(schedIdx, endIdx).map((r) => r._id)
+        );
+        rows = rows.filter((r) => schedRowIds.has(r._id));
+      }
+    }
+    return rows;
+  }, [sheet.rows, scheduleFilter]);
+
+  const columns = useMemo(() => {
+    const map: Record<LineItemStatus, TenderPricingRow[]> = {
+      not_started: [],
+      in_progress: [],
+      review: [],
+      approved: [],
+    };
+    for (const row of items) {
+      const status = (row.status as LineItemStatus) ?? "not_started";
+      map[status].push(row);
+    }
+    return map;
+  }, [items]);
+
+  // Keep selectedRow in sync with sheet data
+  const activeRow = useMemo(() => {
+    if (!selectedRow) return null;
+    return sheet.rows.find((r) => r._id === selectedRow._id) ?? null;
+  }, [selectedRow, sheet.rows]);
+
+  return (
+    <Flex direction="column" h="100%" overflow="hidden">
+      {/* Filter bar */}
+      {schedules.length > 0 && (
+        <Flex px={4} py={2} flexShrink={0} borderBottom="1px solid" borderColor="gray.200">
+          <Select
+            size="sm"
+            w="200px"
+            value={scheduleFilter}
+            onChange={(e) => setScheduleFilter(e.target.value)}
+          >
+            <option value="all">All Schedules</option>
+            {schedules.map((s) => (
+              <option key={s._id} value={s._id}>
+                {s.itemNumber ? `${s.itemNumber} — ` : ""}{s.description || "Untitled"}
+              </option>
+            ))}
+          </Select>
+        </Flex>
+      )}
+
+      {/* Columns */}
+      <Flex flex={1} gap={3} p={3} overflow="hidden">
+        {LINE_ITEM_STATUSES.map((status) => (
+          <BoardColumn
+            key={status}
+            status={status}
+            rows={columns[status]}
+            allRows={sheet.rows}
+            defaultMarkupPct={sheet.defaultMarkupPct}
+            onCardClick={setSelectedRow}
+          />
+        ))}
+      </Flex>
+
+      {/* Drawer */}
+      <PricingBoardDrawer
+        row={activeRow}
+        sheet={sheet}
+        tenderId={tenderId}
+        onClose={() => setSelectedRow(null)}
+        onUpdateRow={onUpdateRow}
+        tenderFiles={tenderFiles}
+      />
+    </Flex>
+  );
+};
+
+export default PricingBoard;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add client/src/components/TenderPricing/PricingBoard.tsx
+git commit -m "feat: PricingBoard Kanban component"
+```
+
+---
+
+### Task 7: Client — PricingBoardDrawer component
+
+**Files:**
+- Create: `client/src/components/TenderPricing/PricingBoardDrawer.tsx`
+
+- [ ] **Step 1: Create `PricingBoardDrawer.tsx`**
+
+```tsx
+import React from "react";
+import {
+  Box,
+  CloseButton,
+  Divider,
+  Flex,
+  Text,
+} from "@chakra-ui/react";
+import { TenderPricingRow, TenderPricingSheet } from "./types";
+import { TenderFileItem } from "../Tender/types";
+import { computeRow, formatCurrency } from "./compute";
+import { EditableCell } from "./PricingRow";
+import StatusDot from "./StatusDot";
+import { LineItemStatus, STATUS_LABELS } from "./statusConstants";
+
+interface PricingBoardDrawerProps {
+  row: TenderPricingRow | null;
+  sheet: TenderPricingSheet;
+  tenderId: string;
+  onClose: () => void;
+  onUpdateRow: (rowId: string, data: Record<string, unknown>) => Promise<void>;
+  tenderFiles?: TenderFileItem[];
+}
+
+const PricingBoardDrawer: React.FC<PricingBoardDrawerProps> = ({
+  row,
+  sheet,
+  onClose,
+  onUpdateRow,
+}) => {
+  if (!row) return null;
+
+  const status = (row.status as LineItemStatus) ?? "not_started";
+  const { effectiveMarkup, suggestedBidUP, lineItemTotal } = computeRow(row, sheet.defaultMarkupPct);
+  const costUP = (row.unitPrice ?? 0) + (row.extraUnitPrice ?? 0);
+
+  return (
+    <Box
+      position="fixed"
+      right={0}
+      top={0}
+      bottom={0}
+      w="400px"
+      maxW="100vw"
+      bg="white"
+      boxShadow="-4px 0 16px rgba(0,0,0,0.1)"
+      zIndex={20}
+      display="flex"
+      flexDir="column"
+      overflowY="auto"
+    >
+      {/* Header */}
+      <Flex px={4} py={3} align="center" justify="space-between" borderBottom="1px solid" borderColor="gray.200" flexShrink={0}>
+        <Flex align="center" gap={3}>
+          <StatusDot status={status} onChange={(s) => onUpdateRow(row._id, { status: s })} />
+          <Text fontSize="sm" fontWeight="semibold" noOfLines={1}>
+            {row.itemNumber ? `${row.itemNumber} — ` : ""}{row.description || "Untitled"}
+          </Text>
+        </Flex>
+        <CloseButton size="sm" onClick={onClose} />
+      </Flex>
+
+      {/* Status label */}
+      <Box px={4} py={2} bg="gray.50" borderBottom="1px solid" borderColor="gray.100">
+        <Text fontSize="xs" color="gray.500">{STATUS_LABELS[status]}</Text>
+      </Box>
+
+      {/* Fields */}
+      <Box px={4} py={4} flex={1}>
+        <Box mb={4}>
+          <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+            Description
+          </Text>
+          <EditableCell
+            value={row.description}
+            onSave={(v) => onUpdateRow(row._id, { description: v })}
+            placeholder="Enter description"
+            wrap
+          />
+        </Box>
+
+        <Flex gap={4} mb={4}>
+          <Box flex={1}>
+            <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+              Quantity
+            </Text>
+            <EditableCell
+              value={row.quantity}
+              onSave={(v) => onUpdateRow(row._id, { quantity: parseFloat(v) || null })}
+              placeholder="—"
+            />
+          </Box>
+          <Box flex={1}>
+            <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+              Unit
+            </Text>
+            <EditableCell
+              value={row.unit}
+              onSave={(v) => onUpdateRow(row._id, { unit: v || null })}
+              placeholder="—"
+            />
+          </Box>
+        </Flex>
+
+        <Divider mb={4} />
+
+        <Flex gap={4} mb={4}>
+          <Box flex={1}>
+            <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+              Cost Unit Price
+            </Text>
+            <Text fontSize="sm" color={costUP > 0 ? "gray.800" : "gray.400"}>
+              {costUP > 0 ? `$${costUP.toFixed(2)}` : "—"}
+            </Text>
+          </Box>
+          <Box flex={1}>
+            <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+              Bid Unit Price
+            </Text>
+            <Text fontSize="sm" fontWeight="medium" color={suggestedBidUP > 0 ? "blue.700" : "gray.400"}>
+              {suggestedBidUP > 0 ? `$${suggestedBidUP.toFixed(2)}` : "—"}
+            </Text>
+          </Box>
+        </Flex>
+
+        <Box mb={4}>
+          <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+            Line Item Total
+          </Text>
+          <Text fontSize="md" fontWeight="semibold" color={lineItemTotal > 0 ? "gray.800" : "gray.400"}>
+            {lineItemTotal > 0 ? formatCurrency(lineItemTotal) : "—"}
+          </Text>
+        </Box>
+
+        <Divider mb={4} />
+
+        <Box mb={4}>
+          <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={1}>
+            Notes
+          </Text>
+          <EditableCell
+            value={row.notes}
+            onSave={(v) => onUpdateRow(row._id, { notes: v || null })}
+            placeholder="Add notes..."
+            wrap
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default PricingBoardDrawer;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add client/src/components/TenderPricing/PricingBoardDrawer.tsx
+git commit -m "feat: PricingBoardDrawer detail drawer for board card clicks"
+```
+
+---
+
+### Task 8: Client — view toggle + wire PricingBoard into tender page
+
+**Files:**
+- Modify: `client/src/pages/tender/[id]/index.tsx`
+- Modify: `client/src/components/TenderPricing/PricingSheet.tsx`
+
+- [ ] **Step 1: Export `handleUpdateRow` from PricingSheet so the board can reuse it**
+
+In `client/src/components/TenderPricing/PricingSheet.tsx`, the `handleUpdateRow` callback is already defined. We need to expose it. Add a new prop to `PricingSheetProps`:
+
+```typescript
+  viewMode?: "list" | "board";
+  onViewModeChange?: (mode: "list" | "board") => void;
+```
+
+At the top of the PricingSheet component render (before the table), add a toolbar row with the view toggle:
+
+```tsx
+      <Flex align="center" gap={2} mb={3} flexShrink={0}>
+        <ButtonGroup size="xs" isAttached variant="outline">
+          <Button
+            onClick={() => onViewModeChange?.("list")}
+            colorScheme={viewMode !== "board" ? "blue" : "gray"}
+            variant={viewMode !== "board" ? "solid" : "outline"}
+          >
+            List
+          </Button>
+          <Button
+            onClick={() => onViewModeChange?.("board")}
+            colorScheme={viewMode === "board" ? "blue" : "gray"}
+            variant={viewMode === "board" ? "solid" : "outline"}
+          >
+            Board
+          </Button>
+        </ButtonGroup>
+        {/* Existing markup controls stay here */}
+      </Flex>
+```
+
+When `viewMode === "board"`, render `PricingBoard` instead of the table/DnD area. Import `PricingBoard` at the top:
+
+```typescript
+import PricingBoard from "./PricingBoard";
+```
+
+In the render, wrap the existing table in a `viewMode !== "board"` check, and add:
+
+```tsx
+      {viewMode === "board" && (
+        <PricingBoard
+          sheet={sheet}
+          tenderId={tenderId}
+          onUpdate={onUpdate}
+          onUpdateRow={handleUpdateRow}
+          tenderFiles={tenderFiles}
+        />
+      )}
+```
+
+- [ ] **Step 2: Add view toggle state to the tender page**
+
+In `client/src/pages/tender/[id]/index.tsx`, add state:
+
+```typescript
+const [pricingViewMode, setPricingViewMode] = useState<"list" | "board">("list");
+```
+
+Pass to `PricingSheet`:
+
+```tsx
+<PricingSheet
+  sheet={sheet}
+  tenderId={tenderId}
+  onUpdate={setSheet}
+  tenderFiles={tender?.files ?? []}
+  activeDocFile={selectedFile?._id}
+  activeDocPage={selectedFilePage}
+  onDocRefClick={handleDocRefClick}
+  viewMode={pricingViewMode}
+  onViewModeChange={setPricingViewMode}
+/>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/components/TenderPricing/PricingSheet.tsx \
+        "client/src/pages/tender/[id]/index.tsx"
+git commit -m "feat: view toggle — list/board switch on pricing sheet"
+```
+
+---
+
+### Task 9: Client — mobile view toggle
+
+**Files:**
+- Modify: `client/src/components/Tender/TenderMobilePricingTab.tsx`
+
+- [ ] **Step 1: Add the same view toggle to the mobile pricing tab**
+
+The mobile tab has its own simpler rendering. Add a `viewMode` state and a `ButtonGroup` toggle at the top. When `viewMode === "board"`, render `PricingBoard` instead of the row list.
+
+Import `PricingBoard`, `ButtonGroup`, `Button` from Chakra, and add:
+
+```typescript
+const [viewMode, setViewMode] = useState<"list" | "board">("list");
+```
+
+Add the toggle before the row list, and conditionally render the board:
+
+```tsx
+<ButtonGroup size="xs" isAttached variant="outline" mb={2}>
+  <Button
+    onClick={() => setViewMode("list")}
+    colorScheme={viewMode === "list" ? "blue" : "gray"}
+    variant={viewMode === "list" ? "solid" : "outline"}
+  >
+    List
+  </Button>
+  <Button
+    onClick={() => setViewMode("board")}
+    colorScheme={viewMode === "board" ? "blue" : "gray"}
+    variant={viewMode === "board" ? "solid" : "outline"}
+  >
+    Board
+  </Button>
+</ButtonGroup>
+
+{viewMode === "board" ? (
+  <PricingBoard
+    sheet={sheet}
+    tenderId={tenderId}
+    onUpdate={onSheetUpdate}
+    onUpdateRow={handleUpdateRow}
+    tenderFiles={tenderFiles}
+  />
+) : (
+  /* existing row list rendering */
+)}
+```
+
+The mobile `handleUpdateRow` already exists — pass it through to PricingBoard.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add client/src/components/Tender/TenderMobilePricingTab.tsx
+git commit -m "feat: add board view toggle to mobile pricing tab"
+```
+
+---
+
+### Task 10: Client — descriptive status events in Review tab
+
+**Files:**
+- Modify: `client/src/components/Tender/TenderReviewTab.tsx`
+
+- [ ] **Step 1: Add `statusTo` to the GQL query**
+
+In `TenderReviewTab.tsx`, add `statusTo` to the `auditLog` fragment in `TENDER_REVIEW_QUERY`:
+
+```graphql
+      auditLog {
+        _id
+        rowId
+        rowDescription
+        action
+        changedFields
+        statusTo
+        changedBy {
+          _id
+          name
+        }
+        changedAt
+      }
+```
+
+Also add `statusTo` to the `AuditEvent` interface:
+
+```typescript
+interface AuditEvent {
+  __typename: "TenderAuditEventClass";
+  _id: string;
+  rowDescription: string;
+  action: "row_added" | "row_deleted" | "row_updated";
+  changedFields: string[];
+  statusTo?: string | null;
+  changedBy?: { _id: string; name: string } | null;
+  changedAt: string;
+}
+```
+
+- [ ] **Step 2: Update `buildActionLabel` for descriptive status events**
+
+Import `STATUS_LABELS` from statusConstants:
+
+```typescript
+import { STATUS_LABELS, LineItemStatus } from "../TenderPricing/statusConstants";
+```
+
+Update `buildActionLabel`:
+
+```typescript
+function buildActionLabel(event: AuditEvent): string {
+  const actor = event.changedBy?.name ?? "Someone";
+  if (event.action === "row_added") return `${actor} added row "${event.rowDescription}"`;
+  if (event.action === "row_deleted") return `${actor} deleted row "${event.rowDescription}"`;
+
+  // Status-only change — descriptive label
+  if (event.statusTo && event.changedFields.length === 1 && event.changedFields[0] === "status") {
+    const label = STATUS_LABELS[event.statusTo as LineItemStatus] ?? event.statusTo;
+    return `${actor} moved "${event.rowDescription}" to ${label}`;
+  }
+
+  // Status change alongside other fields
+  if (event.statusTo) {
+    const label = STATUS_LABELS[event.statusTo as LineItemStatus] ?? event.statusTo;
+    const otherFields = event.changedFields.filter((f) => f !== "status").join(", ");
+    return `${actor} updated "${event.rowDescription}" — ${otherFields}, moved to ${label}`;
+  }
+
+  const fields = event.changedFields.join(", ");
+  return `${actor} updated "${event.rowDescription}" — ${fields}`;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/components/Tender/TenderReviewTab.tsx
+git commit -m "feat: descriptive status change events in Review tab timeline"
+```
+
+---
+
+## Self-Review Checklist
+
+After all tasks are complete, verify:
+
+- [ ] Server starts without TypeScript errors
+- [ ] New rows default to `not_started` status
+- [ ] Clicking the status dot in list view opens popover and changes status
+- [ ] Board view shows items in correct columns based on status
+- [ ] Schedule filter works on the board
+- [ ] Clicking a board card opens the detail drawer
+- [ ] Changing status in the drawer updates the card's column
+- [ ] Status changes appear in the Review tab as "moved [row] to [status]"
+- [ ] Mobile view toggle works
+- [ ] `tenderPricingRowUpdate` with `status` field triggers audit event with `statusTo`

--- a/docs/superpowers/specs/2026-04-09-line-item-status-kanban.md
+++ b/docs/superpowers/specs/2026-04-09-line-item-status-kanban.md
@@ -1,0 +1,140 @@
+# Line Item Status & Kanban Board
+
+**Date:** 2026-04-09
+**Status:** Approved for implementation
+
+## Overview
+
+Add per-line-item status tracking to the tender pricing sheet, with a Kanban board view as an alternative to the current list view. Estimators can mark items as they progress through pricing (Not Started → In Progress → Review → Approved), switch between list and board views, and open items from the board in a detail drawer. Status changes are recorded in the existing audit trail with descriptive labels.
+
+## Scope
+
+1. Add `status` field to `TenderPricingRowClass`
+2. List view: clickable colored status dot on each Item row with popover to change status
+3. Board view: weighted 4-column Kanban with Schedule filter and detail drawer on card click
+4. Audit trail: descriptive "moved to X" events via `statusTo` field on audit events
+
+---
+
+## Step 1 — Data Model
+
+Add to `TenderPricingRowClass` (server schema):
+
+```
+status    "not_started" | "in_progress" | "review" | "approved"    default: "not_started"
+```
+
+- Only meaningful on `type === "Item"` rows. Schedules and Groups ignore it.
+- Updated via the existing `tenderPricingRowUpdate` mutation — no new mutations needed.
+- Add `"status"` to the `TRACKED_ROW_FIELDS` whitelist in `server/src/typescript/tenderReview.ts`.
+- Add optional `statusTo?: string` field to `TenderAuditEventClass` — populated only when a status change is part of the update.
+
+**Files to update:**
+- `server/src/models/TenderPricingSheet/schema/index.ts` — add `status` prop to `TenderPricingRowClass`
+- `server/src/typescript/tenderPricingSheet.ts` — add `status` to `ITenderPricingRowUpdate`
+- `server/src/models/TenderPricingSheet/class/update.ts` — add `status` to `updateRow` and `duplicateRow`
+- `server/src/graphql/resolvers/tenderPricingSheet/mutations.ts` — add `status` to `TenderPricingRowUpdateData`
+- `server/src/typescript/tenderReview.ts` — add `"status"` to `TRACKED_ROW_FIELDS`, add `statusTo` to `ITenderAuditEventCreate`
+- `server/src/models/TenderReview/schema/index.ts` — add optional `statusTo` field to `TenderAuditEventClass`
+- `server/src/graphql/resolvers/tenderPricingSheet/index.ts` — when `data.status` is present, pass `statusTo` to `addAuditEvent`
+- `client/src/components/TenderPricing/types.ts` — add `status` to `TenderPricingRow`
+- Client GQL fragments — add `status` field to all pricing sheet queries
+
+---
+
+## Step 2 — List View: Status Dot
+
+Add a small colored dot (8px circle) to the left of the item number on each Item row in the `PricingRow` component.
+
+**Status colors:**
+| Status | Color | Hex |
+|--------|-------|-----|
+| not_started | Grey | #94a3b8 |
+| in_progress | Blue | #3b82f6 |
+| review | Amber | #ca8a04 |
+| approved | Green | #16a34a |
+
+**Interaction:**
+- Clicking the dot opens a Chakra `Popover` with the four status options listed vertically
+- Each option shows its colored dot + label (e.g. "Not Started", "In Progress", "Ready for Review", "Approved")
+- Selecting an option fires `tenderPricingRowUpdate` with the new status and closes the popover
+- Schedule and Group rows do not show a status dot
+
+**Files:**
+- `client/src/components/TenderPricing/PricingRow.tsx` — add dot + popover
+- New shared constant file or inline: status color map and label map (reused by board view)
+
+---
+
+## Step 3 — View Toggle
+
+A small toggle control at the top of the pricing sheet area, next to existing toolbar controls.
+
+- Two options: **List** (default) and **Board**
+- Simple segmented button or icon toggle (list icon / grid icon)
+- Toggling swaps the entire pricing sheet area between the existing `PricingSheet` component and the new `PricingBoard` component
+- The toggle state is local (not persisted) — defaults to List on page load
+
+**Files:**
+- `client/src/pages/tender/[id]/index.tsx` — add toggle state and conditional rendering
+- `client/src/components/Tender/TenderMobilePricingTab.tsx` — add toggle for mobile (same pattern)
+
+---
+
+## Step 4 — Board View Component
+
+New component `PricingBoard` renders the Kanban board.
+
+**Layout:**
+- Four columns: Not Started (`flex: 2`), In Progress (`flex: 1`), Review (`flex: 1`), Approved (`flex: 1`)
+- Each column has a colored header with status label and item count badge
+- Columns scroll independently when they overflow vertically
+- Background colors match the status (light tints): grey-50, blue-50, amber-50, green-50
+
+**Schedule filter:**
+- A `Select` dropdown at the top of the board: "All Schedules" (default) + one option per Schedule row
+- Filtering shows only Items that belong under that Schedule (based on sort order / indent hierarchy)
+
+**Cards:**
+- Only `type === "Item"` rows appear as cards
+- Card content: item number (e.g. "A.1.3"), description, quantity + unit (e.g. "500 t"), line item total or "—"
+- Cards are sorted by their `sortOrder` within each column
+- Clicking a card opens a detail drawer
+
+**Detail drawer:**
+- Slides in from the right, overlays the board (similar to `LineItemDetail` on mobile)
+- Shows full line item detail: description, quantity, unit, unit price, markup, notes, rate buildup, doc refs
+- Status selector at the top of the drawer (same dot + dropdown pattern as list view, but more prominent)
+- Close button to return to the board
+- Editing fields in the drawer fires the same `tenderPricingRowUpdate` mutations as the list view
+
+**Files:**
+- Create: `client/src/components/TenderPricing/PricingBoard.tsx` — board layout + columns + cards
+- Create: `client/src/components/TenderPricing/PricingBoardDrawer.tsx` — detail drawer for card click
+- Create: `client/src/components/TenderPricing/statusConstants.ts` — shared status colors, labels, types
+
+---
+
+## Step 5 — Audit Trail: Descriptive Status Events
+
+When `tenderPricingRowUpdate` includes a `status` field:
+
+- The audit event includes `statusTo` set to the new status value (e.g. `"in_progress"`)
+- The `TenderReviewTab` timeline renders status events as: **"[Name] moved [row description] to In Progress"** instead of the generic "updated — status" format
+- The `changedFields` array still includes `"status"` alongside any other fields changed in the same mutation
+
+**Files:**
+- `server/src/graphql/resolvers/tenderPricingSheet/index.ts` — extract `data.status` and pass as `statusTo` in the audit event
+- `server/src/models/TenderReview/class/update.ts` — accept and store `statusTo`
+- `client/src/components/Tender/TenderReviewTab.tsx` — update `buildActionLabel` to render descriptive status change text
+
+---
+
+## Out of Scope
+
+- Drag-and-drop between Kanban columns (click-only for now)
+- Swimlanes by Schedule (flat list with filter instead)
+- Persisting the view toggle preference (always defaults to List)
+- Status on Schedule or Group rows
+- Progress bar across the top of the board (can add later)
+- Notifications when items move to Review or Approved

--- a/server/src/__tests__/tenderReview.test.ts
+++ b/server/src/__tests__/tenderReview.test.ts
@@ -1,0 +1,98 @@
+import mongoose from "mongoose";
+import { TenderReview } from "@models";
+import { prepareDatabase } from "@testing/vitestDB";
+
+beforeAll(async () => {
+  await prepareDatabase();
+});
+
+const fakeTenderId = () => new mongoose.Types.ObjectId().toString();
+const fakeUserId = () => new mongoose.Types.ObjectId().toString();
+
+describe("TenderReview.findOrCreateByTenderId", () => {
+  it("creates a document with draft status if none exists", async () => {
+    const tenderId = fakeTenderId();
+    const review = await (TenderReview as any).findOrCreateByTenderId(tenderId);
+    expect(review).not.toBeNull();
+    expect(review.status).toBe("draft");
+    expect(review.auditLog).toHaveLength(0);
+    expect(review.comments).toHaveLength(0);
+  });
+
+  it("returns existing document on second call", async () => {
+    const tenderId = fakeTenderId();
+    const r1 = await (TenderReview as any).findOrCreateByTenderId(tenderId);
+    const r2 = await (TenderReview as any).findOrCreateByTenderId(tenderId);
+    expect(r1._id.toString()).toBe(r2._id.toString());
+  });
+});
+
+describe("TenderReview.addAuditEvent", () => {
+  it("appends an audit event and creates the review if needed", async () => {
+    const tenderId = fakeTenderId();
+    const rowId = new mongoose.Types.ObjectId().toString();
+    await (TenderReview as any).addAuditEvent(tenderId, {
+      rowId,
+      rowDescription: "Supply HMA",
+      action: "row_added",
+      changedFields: [],
+      changedBy: fakeUserId(),
+    });
+    const review = await TenderReview.findOne({ tender: tenderId });
+    expect(review!.auditLog).toHaveLength(1);
+    expect(review!.auditLog[0].action).toBe("row_added");
+    expect(review!.auditLog[0].rowDescription).toBe("Supply HMA");
+  });
+});
+
+describe("TenderReview instance methods", () => {
+  let tenderId: string;
+
+  beforeEach(async () => {
+    tenderId = fakeTenderId();
+    await (TenderReview as any).findOrCreateByTenderId(tenderId);
+  });
+
+  it("setStatus updates the status field", async () => {
+    const review = await (TenderReview as any).findOrCreateByTenderId(tenderId);
+    review.setStatus("in_review");
+    await review.save();
+    const refetched = await TenderReview.findOne({ tender: tenderId });
+    expect(refetched!.status).toBe("in_review");
+  });
+
+  it("addComment appends a comment", async () => {
+    const review = await (TenderReview as any).findOrCreateByTenderId(tenderId);
+    const authorId = fakeUserId();
+    review.addComment("Check the trucking rate", authorId);
+    await review.save();
+    const refetched = await TenderReview.findOne({ tender: tenderId });
+    expect(refetched!.comments).toHaveLength(1);
+    expect(refetched!.comments[0].content).toBe("Check the trucking rate");
+  });
+
+  it("editComment updates content and sets editedAt", async () => {
+    const review = await (TenderReview as any).findOrCreateByTenderId(tenderId);
+    review.addComment("Original text", fakeUserId());
+    await review.save();
+    const saved = await TenderReview.findOne({ tender: tenderId });
+    const commentId = saved!.comments[0]._id;
+    saved!.editComment(commentId, "Updated text");
+    await saved!.save();
+    const refetched = await TenderReview.findOne({ tender: tenderId });
+    expect(refetched!.comments[0].content).toBe("Updated text");
+    expect(refetched!.comments[0].editedAt).toBeDefined();
+  });
+
+  it("deleteComment removes the comment", async () => {
+    const review = await (TenderReview as any).findOrCreateByTenderId(tenderId);
+    review.addComment("To be deleted", fakeUserId());
+    await review.save();
+    const saved = await TenderReview.findOne({ tender: tenderId });
+    const commentId = saved!.comments[0]._id;
+    saved!.deleteComment(commentId);
+    await saved!.save();
+    const refetched = await TenderReview.findOne({ tender: tenderId });
+    expect(refetched!.comments).toHaveLength(0);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -66,6 +66,7 @@ import SystemResolver from "@graphql/resolvers/system";
 import RateBuildupTemplateResolver from "@graphql/resolvers/rateBuildupTemplate";
 import TenderResolver from "@graphql/resolvers/tender";
 import TenderPricingSheetResolver from "@graphql/resolvers/tenderPricingSheet";
+import TenderReviewResolver from "@graphql/resolvers/tenderReview";
 import PublicDocumentResolver from "@graphql/resolvers/publicDocument";
 import TruckingReportResolver from "@graphql/resolvers/truckingReport";
 import UserResolver from "@graphql/resolvers/user";
@@ -133,6 +134,7 @@ const createApp = async () => {
       RateBuildupTemplateResolver,
       TenderResolver,
       TenderPricingSheetResolver,
+      TenderReviewResolver,
       PublicDocumentResolver,
       TruckingReportResolver,
       UserResolver,

--- a/server/src/graphql/resolvers/tenderPricingSheet/index.ts
+++ b/server/src/graphql/resolvers/tenderPricingSheet/index.ts
@@ -111,6 +111,7 @@ export default class TenderPricingSheetResolver {
           action: "row_updated",
           changedFields,
           changedBy: ctx.user._id.toString(),
+          ...(((data as any).status) ? { statusTo: (data as any).status } : {}),
         });
       }
     }

--- a/server/src/graphql/resolvers/tenderPricingSheet/index.ts
+++ b/server/src/graphql/resolvers/tenderPricingSheet/index.ts
@@ -1,9 +1,10 @@
-import { TenderPricingSheet } from "@models";
+import { TenderPricingSheet, TenderReview } from "@models";
 import { TenderPricingSheetClass } from "../../../models/TenderPricingSheet/class";
 import { Id } from "@typescript/models";
 import {
   Arg,
   Authorized,
+  Ctx,
   Float,
   ID,
   Int,
@@ -16,6 +17,8 @@ import {
   TenderPricingRowDocRefAddData,
   TenderPricingRowUpdateData,
 } from "./mutations";
+import { IContext } from "@typescript/graphql";
+import { TRACKED_ROW_FIELDS } from "@typescript/tenderReview";
 
 @Resolver(() => TenderPricingSheetClass)
 export default class TenderPricingSheetResolver {
@@ -63,11 +66,24 @@ export default class TenderPricingSheetResolver {
   @Mutation(() => TenderPricingSheetClass)
   async tenderPricingRowCreate(
     @Arg("sheetId", () => ID) sheetId: Id,
-    @Arg("data") data: TenderPricingRowCreateData
+    @Arg("data") data: TenderPricingRowCreateData,
+    @Ctx() ctx: IContext
   ) {
     const sheet = await TenderPricingSheet.getById(sheetId, { throwError: true });
     sheet!.addRow(data);
     await sheet!.save();
+
+    if (ctx.user) {
+      const newRow = sheet!.rows[sheet!.rows.length - 1];
+      await (TenderReview as any).addAuditEvent((sheet!.tender as any).toString(), {
+        rowId: newRow._id.toString(),
+        rowDescription: newRow.description ?? "",
+        action: "row_added",
+        changedFields: [],
+        changedBy: ctx.user._id.toString(),
+      });
+    }
+
     return sheet;
   }
 
@@ -76,11 +92,29 @@ export default class TenderPricingSheetResolver {
   async tenderPricingRowUpdate(
     @Arg("sheetId", () => ID) sheetId: Id,
     @Arg("rowId", () => ID) rowId: Id,
-    @Arg("data") data: TenderPricingRowUpdateData
+    @Arg("data") data: TenderPricingRowUpdateData,
+    @Ctx() ctx: IContext
   ) {
     const sheet = await TenderPricingSheet.getById(sheetId, { throwError: true });
+    const row = sheet!.rows.find((r) => r._id.toString() === rowId.toString());
     sheet!.updateRow(rowId, data);
     await sheet!.save();
+
+    if (ctx.user) {
+      const changedFields = TRACKED_ROW_FIELDS.filter(
+        (f) => (data as any)[f] !== undefined
+      );
+      if (changedFields.length > 0) {
+        await (TenderReview as any).addAuditEvent((sheet!.tender as any).toString(), {
+          rowId: rowId.toString(),
+          rowDescription: row?.description ?? "",
+          action: "row_updated",
+          changedFields,
+          changedBy: ctx.user._id.toString(),
+        });
+      }
+    }
+
     return sheet;
   }
 
@@ -88,11 +122,24 @@ export default class TenderPricingSheetResolver {
   @Mutation(() => TenderPricingSheetClass)
   async tenderPricingRowDelete(
     @Arg("sheetId", () => ID) sheetId: Id,
-    @Arg("rowId", () => ID) rowId: Id
+    @Arg("rowId", () => ID) rowId: Id,
+    @Ctx() ctx: IContext
   ) {
     const sheet = await TenderPricingSheet.getById(sheetId, { throwError: true });
+    const row = sheet!.rows.find((r) => r._id.toString() === rowId.toString());
     sheet!.deleteRow(rowId);
     await sheet!.save();
+
+    if (ctx.user) {
+      await (TenderReview as any).addAuditEvent((sheet!.tender as any).toString(), {
+        rowId: rowId.toString(),
+        rowDescription: row?.description ?? "",
+        action: "row_deleted",
+        changedFields: [],
+        changedBy: ctx.user._id.toString(),
+      });
+    }
+
     return sheet;
   }
 

--- a/server/src/graphql/resolvers/tenderPricingSheet/index.ts
+++ b/server/src/graphql/resolvers/tenderPricingSheet/index.ts
@@ -20,6 +20,8 @@ import {
 import { IContext } from "@typescript/graphql";
 import { TRACKED_ROW_FIELDS } from "@typescript/tenderReview";
 
+const VALID_ROW_STATUSES = ["not_started", "in_progress", "review", "approved"] as const;
+
 @Resolver(() => TenderPricingSheetClass)
 export default class TenderPricingSheetResolver {
   @Authorized(["ADMIN", "PM"])
@@ -95,6 +97,14 @@ export default class TenderPricingSheetResolver {
     @Arg("data") data: TenderPricingRowUpdateData,
     @Ctx() ctx: IContext
   ) {
+    if (
+      (data as any).status !== undefined &&
+      !VALID_ROW_STATUSES.includes((data as any).status)
+    ) {
+      throw new Error(
+        `Invalid status "${(data as any).status}". Must be one of: ${VALID_ROW_STATUSES.join(", ")}`
+      );
+    }
     const sheet = await TenderPricingSheet.getById(sheetId, { throwError: true });
     const row = sheet!.rows.find((r) => r._id.toString() === rowId.toString());
     sheet!.updateRow(rowId, data);

--- a/server/src/graphql/resolvers/tenderPricingSheet/mutations.ts
+++ b/server/src/graphql/resolvers/tenderPricingSheet/mutations.ts
@@ -53,6 +53,9 @@ export class TenderPricingRowUpdateData {
 
   @Field(() => String, { nullable: true })
   public extraUnitPriceMemo?: string | null;
+
+  @Field(() => String, { nullable: true })
+  public status?: string;
 }
 
 @InputType()

--- a/server/src/graphql/resolvers/tenderPricingSheet/mutations.ts
+++ b/server/src/graphql/resolvers/tenderPricingSheet/mutations.ts
@@ -1,5 +1,5 @@
 import { Field, Float, ID, InputType, Int } from "type-graphql";
-import { TenderPricingRowType, TenderWorkType } from "@typescript/tenderPricingSheet";
+import { TenderPricingRowType } from "@typescript/tenderPricingSheet";
 
 @InputType()
 export class TenderPricingRowCreateData {
@@ -39,17 +39,11 @@ export class TenderPricingRowUpdateData {
   @Field(() => Float, { nullable: true })
   public markupOverride?: number | null;
 
-  @Field({ nullable: true })
-  public calculatorInputsJson?: string;
-
   @Field(() => Float, { nullable: true })
   public unitPrice?: number | null;
 
   @Field({ nullable: true })
   public notes?: string;
-
-  @Field(() => TenderWorkType, { nullable: true })
-  public calculatorType?: TenderWorkType;
 
   @Field(() => String, { nullable: true })
   public rateBuildupSnapshot?: string | null;

--- a/server/src/graphql/resolvers/tenderReview/index.ts
+++ b/server/src/graphql/resolvers/tenderReview/index.ts
@@ -2,6 +2,7 @@ import { TenderReview } from "@models";
 import { TenderReviewClass } from "../../../models/TenderReview/class";
 import { Id } from "@typescript/models";
 import { TenderReviewStatus } from "@typescript/tenderReview";
+import { UserRoles } from "@typescript/user";
 import { Arg, Authorized, Ctx, ID, Mutation, Query, Resolver } from "type-graphql";
 import { IContext } from "@typescript/graphql";
 
@@ -48,9 +49,21 @@ export default class TenderReviewResolver {
   async tenderReviewEditComment(
     @Arg("tenderId", () => ID) tenderId: Id,
     @Arg("commentId", () => ID) commentId: Id,
-    @Arg("content") content: string
+    @Arg("content") content: string,
+    @Ctx() ctx: IContext
   ) {
+    if (!ctx.user) throw new Error("Must be logged in");
     const review = await (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
+    const comment = (review.comments as any[]).find(
+      (c: any) => c._id.toString() === commentId.toString()
+    );
+    if (!comment) throw new Error(`Comment ${commentId} not found`);
+    const isAuthor = comment.author?.toString?.() === ctx.user._id.toString()
+      || comment.author?._id?.toString?.() === ctx.user._id.toString();
+    const isAdmin = ctx.user.role === UserRoles.Admin;
+    if (!isAuthor && !isAdmin) {
+      throw new Error("You can only edit your own comments");
+    }
     review.editComment(commentId, content);
     await review.save();
     return (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
@@ -60,9 +73,21 @@ export default class TenderReviewResolver {
   @Mutation(() => TenderReviewClass)
   async tenderReviewDeleteComment(
     @Arg("tenderId", () => ID) tenderId: Id,
-    @Arg("commentId", () => ID) commentId: Id
+    @Arg("commentId", () => ID) commentId: Id,
+    @Ctx() ctx: IContext
   ) {
+    if (!ctx.user) throw new Error("Must be logged in");
     const review = await (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
+    const comment = (review.comments as any[]).find(
+      (c: any) => c._id.toString() === commentId.toString()
+    );
+    if (!comment) throw new Error(`Comment ${commentId} not found`);
+    const isAuthor = comment.author?.toString?.() === ctx.user._id.toString()
+      || comment.author?._id?.toString?.() === ctx.user._id.toString();
+    const isAdmin = ctx.user.role === UserRoles.Admin;
+    if (!isAuthor && !isAdmin) {
+      throw new Error("You can only delete your own comments");
+    }
     review.deleteComment(commentId);
     await review.save();
     return (TenderReview as any).findOrCreateByTenderId(tenderId.toString());

--- a/server/src/graphql/resolvers/tenderReview/index.ts
+++ b/server/src/graphql/resolvers/tenderReview/index.ts
@@ -19,6 +19,9 @@ export default class TenderReviewResolver {
     @Arg("tenderId", () => ID) tenderId: Id,
     @Arg("status") status: string
   ) {
+    const VALID: TenderReviewStatus[] = ["draft", "in_review", "approved"];
+    if (!VALID.includes(status as TenderReviewStatus))
+      throw new Error(`Invalid status "${status}". Must be one of: ${VALID.join(", ")}`);
     const review = await (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
     review.setStatus(status as TenderReviewStatus);
     await review.save();

--- a/server/src/graphql/resolvers/tenderReview/index.ts
+++ b/server/src/graphql/resolvers/tenderReview/index.ts
@@ -1,0 +1,67 @@
+import { TenderReview } from "@models";
+import { TenderReviewClass } from "../../../models/TenderReview/class";
+import { Id } from "@typescript/models";
+import { TenderReviewStatus } from "@typescript/tenderReview";
+import { Arg, Authorized, Ctx, ID, Mutation, Query, Resolver } from "type-graphql";
+import { IContext } from "@typescript/graphql";
+
+@Resolver(() => TenderReviewClass)
+export default class TenderReviewResolver {
+  @Authorized(["ADMIN", "PM"])
+  @Query(() => TenderReviewClass)
+  async tenderReview(@Arg("tenderId", () => ID) tenderId: Id) {
+    return (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
+  }
+
+  @Authorized(["ADMIN", "PM"])
+  @Mutation(() => TenderReviewClass)
+  async tenderReviewSetStatus(
+    @Arg("tenderId", () => ID) tenderId: Id,
+    @Arg("status") status: string
+  ) {
+    const review = await (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
+    review.setStatus(status as TenderReviewStatus);
+    await review.save();
+    // Re-fetch with population
+    return (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
+  }
+
+  @Authorized(["ADMIN", "PM"])
+  @Mutation(() => TenderReviewClass)
+  async tenderReviewAddComment(
+    @Arg("tenderId", () => ID) tenderId: Id,
+    @Arg("content") content: string,
+    @Ctx() ctx: IContext
+  ) {
+    if (!ctx.user) throw new Error("Must be logged in");
+    const review = await (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
+    review.addComment(content, ctx.user._id.toString());
+    await review.save();
+    return (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
+  }
+
+  @Authorized(["ADMIN", "PM"])
+  @Mutation(() => TenderReviewClass)
+  async tenderReviewEditComment(
+    @Arg("tenderId", () => ID) tenderId: Id,
+    @Arg("commentId", () => ID) commentId: Id,
+    @Arg("content") content: string
+  ) {
+    const review = await (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
+    review.editComment(commentId, content);
+    await review.save();
+    return (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
+  }
+
+  @Authorized(["ADMIN", "PM"])
+  @Mutation(() => TenderReviewClass)
+  async tenderReviewDeleteComment(
+    @Arg("tenderId", () => ID) tenderId: Id,
+    @Arg("commentId", () => ID) commentId: Id
+  ) {
+    const review = await (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
+    review.deleteComment(commentId);
+    await review.save();
+    return (TenderReview as any).findOrCreateByTenderId(tenderId.toString());
+  }
+}

--- a/server/src/models/TenderPricingSheet/class/update.ts
+++ b/server/src/models/TenderPricingSheet/class/update.ts
@@ -48,6 +48,7 @@ const updateRow = (
   if (data.rateBuildupSnapshot !== undefined) row.rateBuildupSnapshot = data.rateBuildupSnapshot ?? undefined;
   if (data.extraUnitPrice !== undefined) row.extraUnitPrice = data.extraUnitPrice;
   if (data.extraUnitPriceMemo !== undefined) row.extraUnitPriceMemo = data.extraUnitPriceMemo ?? undefined;
+  if (data.status !== undefined) row.status = data.status;
 
   sheet.updatedAt = new Date();
   return sheet;
@@ -136,6 +137,7 @@ const duplicateRow = (
     rateBuildupSnapshot: src.rateBuildupSnapshot,
     extraUnitPrice: src.extraUnitPrice,
     extraUnitPriceMemo: src.extraUnitPriceMemo,
+    status: src.status,
     docRefs: ((src as any).docRefs ?? []).map((r: any) => ({ ...r, _id: new Types.ObjectId() })),
   };
 

--- a/server/src/models/TenderPricingSheet/class/update.ts
+++ b/server/src/models/TenderPricingSheet/class/update.ts
@@ -43,11 +43,8 @@ const updateRow = (
   if (data.quantity !== undefined) row.quantity = data.quantity;
   if (data.unit !== undefined) row.unit = data.unit;
   if (data.markupOverride !== undefined) row.markupOverride = data.markupOverride;
-  if (data.calculatorInputsJson !== undefined) row.calculatorInputsJson = data.calculatorInputsJson;
   if (data.unitPrice !== undefined) row.unitPrice = data.unitPrice;
   if (data.notes !== undefined) row.notes = data.notes;
-  if (data.calculatorType !== undefined) row.calculatorType = data.calculatorType;
-  if (data.calculatorInputs !== undefined) row.calculatorInputs = data.calculatorInputs as any;
   if (data.rateBuildupSnapshot !== undefined) row.rateBuildupSnapshot = data.rateBuildupSnapshot ?? undefined;
   if (data.extraUnitPrice !== undefined) row.extraUnitPrice = data.extraUnitPrice;
   if (data.extraUnitPriceMemo !== undefined) row.extraUnitPriceMemo = data.extraUnitPriceMemo ?? undefined;
@@ -136,8 +133,6 @@ const duplicateRow = (
     markupOverride: src.markupOverride,
     unitPrice: src.unitPrice,
     notes: src.notes,
-    calculatorType: src.calculatorType,
-    calculatorInputsJson: src.calculatorInputsJson,
     rateBuildupSnapshot: src.rateBuildupSnapshot,
     extraUnitPrice: src.extraUnitPrice,
     extraUnitPriceMemo: src.extraUnitPriceMemo,

--- a/server/src/models/TenderPricingSheet/schema/index.ts
+++ b/server/src/models/TenderPricingSheet/schema/index.ts
@@ -1,5 +1,5 @@
-import { TenderPricingRowType, TenderWorkType } from "@typescript/tenderPricingSheet";
-import { modelOptions, prop, Severity } from "@typegoose/typegoose";
+import { TenderPricingRowType } from "@typescript/tenderPricingSheet";
+import { prop } from "@typegoose/typegoose";
 import { Types } from "mongoose";
 import { Field, Float, ID, Int, ObjectType } from "type-graphql";
 
@@ -21,7 +21,6 @@ export class DocRefClass {
   public description?: string;
 }
 
-@modelOptions({ options: { allowMixed: Severity.ALLOW } })
 @ObjectType()
 export class TenderPricingRowClass {
   @Field(() => ID)
@@ -60,10 +59,6 @@ export class TenderPricingRowClass {
   @prop()
   public markupOverride?: number | null;
 
-  @Field({ nullable: true })
-  @prop({ trim: true })
-  public calculatorInputsJson?: string;
-
   @Field(() => Float, { nullable: true })
   @prop()
   public unitPrice?: number | null;
@@ -71,13 +66,6 @@ export class TenderPricingRowClass {
   @Field({ nullable: true })
   @prop({ trim: true })
   public notes?: string;
-
-  @Field(() => TenderWorkType, { nullable: true })
-  @prop({ enum: TenderWorkType })
-  public calculatorType?: TenderWorkType;
-
-  @prop({ type: () => Object })
-  public calculatorInputs?: Record<string, unknown>;
 
   @Field({ nullable: true })
   @prop({ trim: true })

--- a/server/src/models/TenderPricingSheet/schema/index.ts
+++ b/server/src/models/TenderPricingSheet/schema/index.ts
@@ -82,6 +82,10 @@ export class TenderPricingRowClass {
   @Field(() => [DocRefClass])
   @prop({ type: () => [DocRefClass], default: [] })
   public docRefs!: DocRefClass[];
+
+  @Field(() => String, { nullable: true })
+  @prop({ trim: true, default: "not_started" })
+  public status?: string;
 }
 
 @ObjectType()

--- a/server/src/models/TenderReview/class/create.ts
+++ b/server/src/models/TenderReview/class/create.ts
@@ -1,0 +1,15 @@
+import { TenderReviewDocument, TenderReviewModel } from "@models";
+
+const document = async (
+  TenderReview: TenderReviewModel,
+  tenderId: string
+): Promise<TenderReviewDocument> => {
+  return new TenderReview({
+    tender: tenderId,
+    status: "draft",
+    auditLog: [],
+    comments: [],
+  });
+};
+
+export default { document };

--- a/server/src/models/TenderReview/class/get.ts
+++ b/server/src/models/TenderReview/class/get.ts
@@ -1,0 +1,29 @@
+import { TenderReviewDocument, TenderReviewModel } from "@models";
+import { Id, GetByIDOptions } from "@typescript/models";
+
+const byTenderId = async (
+  TenderReview: TenderReviewModel,
+  tenderId: Id
+): Promise<TenderReviewDocument | null> => {
+  return TenderReview.findOne({ tender: tenderId })
+    .populate({ path: "auditLog.changedBy", select: "name" })
+    .populate({ path: "comments.author", select: "name" });
+};
+
+const byId = async (
+  TenderReview: TenderReviewModel,
+  id: Id,
+  options?: GetByIDOptions
+): Promise<TenderReviewDocument | null> => {
+  const query = TenderReview.findById(id)
+    .populate({ path: "auditLog.changedBy", select: "name" })
+    .populate({ path: "comments.author", select: "name" });
+  if (options?.throwError) {
+    const doc = await query;
+    if (!doc) throw new Error(`TenderReview ${id} not found`);
+    return doc;
+  }
+  return query;
+};
+
+export default { byTenderId, byId };

--- a/server/src/models/TenderReview/class/index.ts
+++ b/server/src/models/TenderReview/class/index.ts
@@ -1,0 +1,92 @@
+import { ObjectType } from "type-graphql";
+import { TenderReviewDocument, TenderReviewModel } from "@models";
+import { Id, GetByIDOptions } from "@typescript/models";
+import { TenderReviewStatus, ITenderAuditEventCreate } from "@typescript/tenderReview";
+import { TenderReviewSchema } from "../schema";
+import get from "./get";
+import create from "./create";
+import update from "./update";
+
+@ObjectType()
+export class TenderReviewClass extends TenderReviewSchema {
+  public static async getById(
+    this: TenderReviewModel,
+    id: Id,
+    options?: GetByIDOptions
+  ) {
+    return get.byId(this, id, options);
+  }
+
+  public static async getByTenderId(
+    this: TenderReviewModel,
+    tenderId: Id
+  ) {
+    return get.byTenderId(this, tenderId);
+  }
+
+  public static async createDocument(
+    this: TenderReviewModel,
+    tenderId: string
+  ) {
+    return create.document(this, tenderId);
+  }
+
+  public static async findOrCreateByTenderId(
+    this: TenderReviewModel,
+    tenderId: string
+  ): Promise<TenderReviewDocument> {
+    let review = await get.byTenderId(this, tenderId);
+    if (!review) {
+      review = await create.document(this, tenderId);
+      await (review as TenderReviewDocument).save();
+      // Re-fetch to get populated fields
+      review = (await get.byTenderId(this, tenderId))!;
+    }
+    return review as TenderReviewDocument;
+  }
+
+  public static async addAuditEvent(
+    this: TenderReviewModel,
+    tenderId: string,
+    event: ITenderAuditEventCreate
+  ) {
+    // Use lean find-or-create without population for mutation speed
+    let review = await this.findOne({ tender: tenderId });
+    if (!review) {
+      review = await create.document(this, tenderId);
+      await (review as TenderReviewDocument).save();
+    }
+    update.addAuditEvent(review as TenderReviewDocument, event);
+    await (review as TenderReviewDocument).save();
+  }
+
+  public setStatus(
+    this: TenderReviewDocument,
+    status: TenderReviewStatus
+  ) {
+    return update.setStatus(this, status);
+  }
+
+  public addComment(
+    this: TenderReviewDocument,
+    content: string,
+    authorId: string
+  ) {
+    return update.addComment(this, content, authorId);
+  }
+
+  public editComment(
+    this: TenderReviewDocument,
+    commentId: Id,
+    content: string
+  ) {
+    return update.editComment(this, commentId, content);
+  }
+
+  public deleteComment(
+    this: TenderReviewDocument,
+    commentId: Id
+  ) {
+    return update.deleteComment(this, commentId);
+  }
+}

--- a/server/src/models/TenderReview/class/index.ts
+++ b/server/src/models/TenderReview/class/index.ts
@@ -37,9 +37,13 @@ export class TenderReviewClass extends TenderReviewSchema {
   ): Promise<TenderReviewDocument> {
     let review = await get.byTenderId(this, tenderId);
     if (!review) {
-      review = await create.document(this, tenderId);
-      await (review as TenderReviewDocument).save();
-      // Re-fetch to get populated fields
+      try {
+        const doc = await create.document(this, tenderId);
+        await (doc as TenderReviewDocument).save();
+      } catch (err: any) {
+        // Ignore duplicate key — concurrent create won
+        if (err?.code !== 11000) throw err;
+      }
       review = (await get.byTenderId(this, tenderId))!;
     }
     return review as TenderReviewDocument;
@@ -53,8 +57,16 @@ export class TenderReviewClass extends TenderReviewSchema {
     // Use lean find-or-create without population for mutation speed
     let review = await this.findOne({ tender: tenderId });
     if (!review) {
-      review = await create.document(this, tenderId);
-      await (review as TenderReviewDocument).save();
+      try {
+        const doc = await create.document(this, tenderId);
+        update.addAuditEvent(doc as TenderReviewDocument, event);
+        await (doc as TenderReviewDocument).save();
+        return;
+      } catch (err: any) {
+        // Duplicate key — concurrent create won, fall through to find + push
+        if (err?.code !== 11000) throw err;
+        review = await this.findOne({ tender: tenderId });
+      }
     }
     update.addAuditEvent(review as TenderReviewDocument, event);
     await (review as TenderReviewDocument).save();

--- a/server/src/models/TenderReview/class/update.ts
+++ b/server/src/models/TenderReview/class/update.ts
@@ -24,6 +24,7 @@ const addAuditEvent = (
     changedFields: event.changedFields,
     changedBy: new Types.ObjectId(event.changedBy),
     changedAt: new Date(),
+    ...(event.statusTo ? { statusTo: event.statusTo } : {}),
   });
   review.updatedAt = new Date();
   return review;

--- a/server/src/models/TenderReview/class/update.ts
+++ b/server/src/models/TenderReview/class/update.ts
@@ -1,0 +1,73 @@
+import { Types } from "mongoose";
+import { TenderReviewDocument } from "@models";
+import { TenderReviewStatus, ITenderAuditEventCreate } from "@typescript/tenderReview";
+import { Id } from "@typescript/models";
+
+const setStatus = (
+  review: TenderReviewDocument,
+  status: TenderReviewStatus
+): TenderReviewDocument => {
+  review.status = status;
+  review.updatedAt = new Date();
+  return review;
+};
+
+const addAuditEvent = (
+  review: TenderReviewDocument,
+  event: ITenderAuditEventCreate
+): TenderReviewDocument => {
+  (review.auditLog as any).push({
+    _id: new Types.ObjectId(),
+    rowId: new Types.ObjectId(event.rowId),
+    rowDescription: event.rowDescription,
+    action: event.action,
+    changedFields: event.changedFields,
+    changedBy: new Types.ObjectId(event.changedBy),
+    changedAt: new Date(),
+  });
+  review.updatedAt = new Date();
+  return review;
+};
+
+const addComment = (
+  review: TenderReviewDocument,
+  content: string,
+  authorId: string
+): TenderReviewDocument => {
+  (review.comments as any).push({
+    _id: new Types.ObjectId(),
+    content,
+    author: new Types.ObjectId(authorId),
+    createdAt: new Date(),
+  });
+  review.updatedAt = new Date();
+  return review;
+};
+
+const editComment = (
+  review: TenderReviewDocument,
+  commentId: Id,
+  content: string
+): TenderReviewDocument => {
+  const comment = (review.comments as any[]).find(
+    (c: any) => c._id.toString() === commentId.toString()
+  );
+  if (!comment) throw new Error(`Comment ${commentId} not found`);
+  comment.content = content;
+  comment.editedAt = new Date();
+  review.updatedAt = new Date();
+  return review;
+};
+
+const deleteComment = (
+  review: TenderReviewDocument,
+  commentId: Id
+): TenderReviewDocument => {
+  (review as any).comments = (review.comments as any[]).filter(
+    (c: any) => c._id.toString() !== commentId.toString()
+  );
+  review.updatedAt = new Date();
+  return review;
+};
+
+export default { setStatus, addAuditEvent, addComment, editComment, deleteComment };

--- a/server/src/models/TenderReview/index.ts
+++ b/server/src/models/TenderReview/index.ts
@@ -1,0 +1,2 @@
+export * from "./schema";
+export * from "./class";

--- a/server/src/models/TenderReview/schema/index.ts
+++ b/server/src/models/TenderReview/schema/index.ts
@@ -17,7 +17,7 @@ export class TenderAuditEventClass {
   @prop({ required: true, default: "" })
   public rowDescription!: string;
 
-  @Field()
+  @Field(() => String)
   @prop({ required: true })
   public action!: TenderAuditAction;
 
@@ -65,7 +65,7 @@ export class TenderReviewSchema {
   @prop({ required: true, unique: true })
   public tender!: Types.ObjectId;
 
-  @Field()
+  @Field(() => String)
   @prop({ required: true, default: "draft" })
   public status!: TenderReviewStatus;
 

--- a/server/src/models/TenderReview/schema/index.ts
+++ b/server/src/models/TenderReview/schema/index.ts
@@ -32,6 +32,10 @@ export class TenderAuditEventClass {
   @Field()
   @prop({ required: true })
   public changedAt!: Date;
+
+  @Field(() => String, { nullable: true })
+  @prop({ trim: true })
+  public statusTo?: string;
 }
 
 @ObjectType()

--- a/server/src/models/TenderReview/schema/index.ts
+++ b/server/src/models/TenderReview/schema/index.ts
@@ -1,0 +1,87 @@
+import { TenderReviewStatus, TenderAuditAction } from "@typescript/tenderReview";
+import { prop, Ref } from "@typegoose/typegoose";
+import { Types } from "mongoose";
+import { Field, ID, ObjectType } from "type-graphql";
+import { UserClass } from "../../User/class";
+
+@ObjectType()
+export class TenderAuditEventClass {
+  @Field(() => ID)
+  public _id!: Types.ObjectId;
+
+  @Field(() => ID)
+  @prop({ required: true })
+  public rowId!: Types.ObjectId;
+
+  @Field()
+  @prop({ required: true, default: "" })
+  public rowDescription!: string;
+
+  @Field()
+  @prop({ required: true })
+  public action!: TenderAuditAction;
+
+  @Field(() => [String])
+  @prop({ type: () => [String], default: [] })
+  public changedFields!: string[];
+
+  @Field(() => UserClass, { nullable: true })
+  @prop({ ref: () => UserClass, required: false })
+  public changedBy?: Ref<UserClass>;
+
+  @Field()
+  @prop({ required: true })
+  public changedAt!: Date;
+}
+
+@ObjectType()
+export class TenderReviewCommentClass {
+  @Field(() => ID)
+  public _id!: Types.ObjectId;
+
+  @Field()
+  @prop({ required: true })
+  public content!: string;
+
+  @Field(() => UserClass, { nullable: true })
+  @prop({ ref: () => UserClass, required: false })
+  public author?: Ref<UserClass>;
+
+  @Field()
+  @prop({ required: true })
+  public createdAt!: Date;
+
+  @Field({ nullable: true })
+  @prop()
+  public editedAt?: Date;
+}
+
+@ObjectType()
+export class TenderReviewSchema {
+  @Field(() => ID)
+  public _id!: Types.ObjectId;
+
+  // Not exposed as a GQL field — queried via tenderReview(tenderId)
+  @prop({ required: true, unique: true })
+  public tender!: Types.ObjectId;
+
+  @Field()
+  @prop({ required: true, default: "draft" })
+  public status!: TenderReviewStatus;
+
+  @Field(() => [TenderAuditEventClass])
+  @prop({ type: () => [TenderAuditEventClass], default: [] })
+  public auditLog!: TenderAuditEventClass[];
+
+  @Field(() => [TenderReviewCommentClass])
+  @prop({ type: () => [TenderReviewCommentClass], default: [] })
+  public comments!: TenderReviewCommentClass[];
+
+  @Field()
+  @prop({ required: true, default: Date.now })
+  public createdAt!: Date;
+
+  @Field()
+  @prop({ required: true, default: Date.now })
+  public updatedAt!: Date;
+}

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -22,6 +22,7 @@ export * from "./System";
 export * from "./RateBuildupTemplate";
 export * from "./Tender";
 export * from "./TenderPricingSheet";
+export * from "./TenderReview";
 export * from "./User";
 export * from "./Vehicle";
 export * from "./VehicleIssue";
@@ -471,4 +472,18 @@ export type TenderPricingSheetModel = ReturnModelType<typeof TenderPricingSheetC
 
 export const TenderPricingSheet = getModelForClass(TenderPricingSheetClass, {
   schemaOptions: { collection: "tenderpricingsheets" },
+});
+
+/**
+ * ----- TenderReview -----
+ */
+
+import { TenderReviewClass } from "./TenderReview/class";
+
+export type TenderReviewDocument = DocumentType<TenderReviewClass>;
+
+export type TenderReviewModel = ReturnModelType<typeof TenderReviewClass>;
+
+export const TenderReview = getModelForClass(TenderReviewClass, {
+  schemaOptions: { collection: "tenderreviews" },
 });

--- a/server/src/typescript/tenderPricingSheet.ts
+++ b/server/src/typescript/tenderPricingSheet.ts
@@ -8,42 +8,6 @@ export enum TenderPricingRowType {
 }
 registerEnumType(TenderPricingRowType, { name: "TenderPricingRowType" });
 
-export enum TenderWorkType {
-  Paving = "Paving",
-  Toplift = "Toplift",
-  Gravel = "Gravel",
-  SubgradePrep = "SubgradePrep",
-  CommonExcavation = "CommonExcavation",
-  Concrete = "Concrete",
-}
-registerEnumType(TenderWorkType, { name: "TenderWorkType" });
-
-export interface ITenderCrewEntry {
-  role: string;
-  quantity: number;
-  ratePerHour: number;
-}
-
-export interface ITenderEquipEntry {
-  name: string;
-  quantity: number;
-  ratePerHour: number;
-}
-
-export interface ITenderCalculatorInputs {
-  productionRate?: number;
-  crew?: ITenderCrewEntry[];
-  equipment?: ITenderEquipEntry[];
-  depth_mm?: number;
-  density?: number;
-  materialCostPerUnit?: number;
-  truckingMethod?: "perTonne" | "perHour";
-  truckingRatePerTonne?: number;
-  numTrucks?: number;
-  truckingRatePerHour?: number;
-  [key: string]: unknown;
-}
-
 export interface IDocRef {
   enrichedFileId: string | Types.ObjectId;
   page: number;
@@ -69,11 +33,8 @@ export interface ITenderPricingRowUpdate {
   quantity?: number;
   unit?: string;
   markupOverride?: number | null;
-  calculatorInputsJson?: string;
   unitPrice?: number | null;
   notes?: string;
-  calculatorType?: TenderWorkType;
-  calculatorInputs?: ITenderCalculatorInputs;
   rateBuildupSnapshot?: string | null;
   extraUnitPrice?: number | null;
   extraUnitPriceMemo?: string | null;

--- a/server/src/typescript/tenderPricingSheet.ts
+++ b/server/src/typescript/tenderPricingSheet.ts
@@ -38,4 +38,5 @@ export interface ITenderPricingRowUpdate {
   rateBuildupSnapshot?: string | null;
   extraUnitPrice?: number | null;
   extraUnitPriceMemo?: string | null;
+  status?: string;
 }

--- a/server/src/typescript/tenderReview.ts
+++ b/server/src/typescript/tenderReview.ts
@@ -13,6 +13,7 @@ export const TRACKED_ROW_FIELDS: string[] = [
   "description",
   "itemNumber",
   "notes",
+  "status",
 ];
 
 export interface ITenderAuditEventCreate {
@@ -21,4 +22,5 @@ export interface ITenderAuditEventCreate {
   action: TenderAuditAction;
   changedFields: string[];
   changedBy: string; // User _id as string
+  statusTo?: string;
 }

--- a/server/src/typescript/tenderReview.ts
+++ b/server/src/typescript/tenderReview.ts
@@ -1,0 +1,24 @@
+export type TenderReviewStatus = "draft" | "in_review" | "approved";
+
+export type TenderAuditAction = "row_added" | "row_deleted" | "row_updated";
+
+export const TRACKED_ROW_FIELDS: string[] = [
+  "quantity",
+  "unit",
+  "unitPrice",
+  "markupOverride",
+  "rateBuildupSnapshot",
+  "extraUnitPrice",
+  "extraUnitPriceMemo",
+  "description",
+  "itemNumber",
+  "notes",
+];
+
+export interface ITenderAuditEventCreate {
+  rowId: string;
+  rowDescription: string;
+  action: TenderAuditAction;
+  changedFields: string[];
+  changedBy: string; // User _id as string
+}


### PR DESCRIPTION
## Summary

Two major features merged from \`feature/tender-review-audit-trail\`:

### Tender Review & Audit Trail
- New \`TenderReview\` MongoDB model with row-level audit log + review comments
- Review tab on tender page with chronological timeline (audit events + comments)
- Review status: Draft / In Review / Approved
- PR-style approval warning when line items aren't all approved

### Line Item Status & Kanban Board
- \`status\` field on pricing rows: Not Started / In Progress / Ready for Review / Approved
- Clickable StatusDot in list view (popover to change)
- New Kanban board view as alternative to list view (toggle on the Pricing tab)
- Bottom drawer for board card clicks (reuses LineItemDetail with status pills)
- Prominent Rate Buildup template CTA card for empty line items
- Compact inline markup override row
- Status changes appear in Review timeline as "moved [row] to [status]"

### Hardening
- Server-side validation for row status against allowed values
- Comment authorship enforcement on edit/delete (admin override allowed)
- Race-safe \`findOrCreateByTenderId\` with duplicate-key handling

## Test plan
- [ ] Tender page → Review tab — verify timeline shows row changes + comments
- [ ] Pricing tab → Board toggle — verify Kanban renders, click cards, change statuses
- [ ] Edit a line item — verify status pills appear in Details header
- [ ] Empty line item — verify the Rate Buildup CTA is prominent
- [ ] Try to approve review with unapproved items — verify warning dialog
- [ ] Add a comment in the Review tab — verify it appears in timeline
- [ ] Edit/delete your own comment — verify it works; check that you can't edit another user's

🤖 Generated with [Claude Code](https://claude.com/claude-code)