### PR TITLE
Tender pricing test suite + evaluator fix + iOS PWA fix + enriched files loop fix

### DIFF
--- a/client/playwright/e2e-global-setup.ts
+++ b/client/playwright/e2e-global-setup.ts
@@ -49,11 +49,13 @@ export default async function globalSetup() {
   const page = await context.newPage();
 
   console.log("[e2e-setup] Logging in as admin to capture auth state...");
-  await page.goto("/login");
+  // Next.js dev mode compiles each page on first request. Cold-compile of
+  // /login can take 60s+ on the first run after a fresh webServer start.
+  await page.goto("/login", { timeout: 120_000 });
   await page.getByLabel("Email").fill("admin@bowmark.ca");
   await page.getByLabel("Password").fill("password");
   await page.getByRole("button", { name: /submit/i }).click();
-  await expect(page).not.toHaveURL(/login/, { timeout: 15_000 });
+  await expect(page).not.toHaveURL(/login/, { timeout: 30_000 });
 
   await context.storageState({ path: path.join(authDir, "admin.json") });
   console.log("[e2e-setup] Auth state saved.");

--- a/client/public/manifest-concrete.json
+++ b/client/public/manifest-concrete.json
@@ -3,7 +3,7 @@
   "short_name": "Concrete",
   "theme_color": "#ef2e25",
   "background_color": "#edf2f7",
-  "display": "fullscreen",
+  "display": "standalone",
   "orientation": "portrait",
   "start_url": "/",
   "icons": [

--- a/client/public/manifest-paving.json
+++ b/client/public/manifest-paving.json
@@ -3,7 +3,7 @@
   "short_name": "Paving",
   "theme_color": "#ef2e25",
   "background_color": "#edf2f7",
-  "display": "fullscreen",
+  "display": "standalone",
   "orientation": "portrait",
   "start_url": "/",
   "icons": [

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Bow Mark",
   "theme_color": "#ef2e25",
   "background_color": "#edf2f7",
-  "display": "fullscreen",
+  "display": "standalone",
   "orientation": "portrait",
   "start_url": "/",
   "icons": [

--- a/client/src/components/TenderPricing/LineItemDetail.tsx
+++ b/client/src/components/TenderPricing/LineItemDetail.tsx
@@ -810,7 +810,7 @@ const LineItemDetail: React.FC<LineItemDetailProps> = ({
                       <Text fontSize="9px" fontWeight="medium" color="orange.400" textTransform="uppercase" letterSpacing="wide">
                         Unit Price
                       </Text>
-                      <Text fontSize="xs" fontWeight="bold" color="orange.700">
+                      <Text data-testid="buildup-unit-price" fontSize="xs" fontWeight="bold" color="orange.700">
                         ${((snapResult?.unitPrice ?? row.unitPrice ?? 0) + (row.extraUnitPrice ?? 0)).toFixed(2)}
                       </Text>
                     </Box>

--- a/client/src/components/TenderPricing/PricingRow.tsx
+++ b/client/src/components/TenderPricing/PricingRow.tsx
@@ -480,7 +480,7 @@ const ItemRow: React.FC<ItemRowProps> = ({
         </Text>
       </Td>
       <Td isNumeric whiteSpace="nowrap">
-        <Text fontSize="sm" color={costUP > 0 ? "gray.800" : "gray.400"}>
+        <Text data-testid="row-cost-up" fontSize="sm" color={costUP > 0 ? "gray.800" : "gray.400"}>
           {costUP > 0 ? `$${costUP.toFixed(2)}` : "—"}
         </Text>
       </Td>

--- a/client/src/components/TenderPricing/calculators/__tests__/evaluateTemplate.test.ts
+++ b/client/src/components/TenderPricing/calculators/__tests__/evaluateTemplate.test.ts
@@ -431,3 +431,110 @@ describe("evaluateTemplate — edge cases", () => {
     expect(result.unitPrice).toBe(0);
   });
 });
+
+// ─── Per-unit convention: fixed cost / quantity ──────────────────────────────
+//
+// Real templates feed per-unit values into the breakdown. If a cost is fixed
+// across the whole row (setup, equipment hauling, lump-sum labour), the
+// author divides by quantity to get the per-unit share. This describes a
+// template where the unit price DECREASES as quantity increases, which is
+// exactly how fixed/amortised costs behave in production templates.
+describe("evaluateTemplate — fixed cost / quantity convention", () => {
+  it("pure fixed cost per unit shrinks as quantity grows", () => {
+    // $1000 fixed setup spread across the row
+    const template = tmpl({
+      formulaSteps: [{ id: "setup_per_unit", formula: "1000 / quantity" }],
+      breakdownDefs: [
+        {
+          id: "bd1",
+          label: "Setup",
+          items: [{ stepId: "setup_per_unit", label: "Setup / unit" }],
+        },
+      ],
+    });
+
+    expect(evaluateTemplate(template, undefined, 100).unitPrice).toBe(10);
+    expect(evaluateTemplate(template, undefined, 1000).unitPrice).toBe(1);
+    expect(evaluateTemplate(template, undefined, 2000).unitPrice).toBe(0.5);
+  });
+
+  it("mixed variable + fixed: variable stays constant, fixed shrinks", () => {
+    // Realistic paving: variable cost per unit (depth × density × $/t) is
+    // independent of quantity. Fixed labour lump-sum is spread across the row.
+    const template = tmpl({
+      parameterDefs: [
+        { id: "depth_m", label: "Depth", defaultValue: 0.05 },
+        { id: "density", label: "Density", defaultValue: 2.4 },
+        { id: "price_per_t", label: "$/t", defaultValue: 120 },
+        { id: "labour_lump", label: "Labour Lump $", defaultValue: 5000 },
+      ],
+      formulaSteps: [
+        // Per-unit material cost: depth * density * price. No quantity.
+        { id: "mat_per_unit", formula: "depth_m * density * price_per_t" },
+        // Per-unit labour share: lump / quantity
+        { id: "lab_per_unit", formula: "labour_lump / quantity" },
+      ],
+      breakdownDefs: [
+        {
+          id: "bd_mat",
+          label: "Material",
+          items: [{ stepId: "mat_per_unit", label: "Material" }],
+        },
+        {
+          id: "bd_lab",
+          label: "Labour",
+          items: [{ stepId: "lab_per_unit", label: "Labour" }],
+        },
+      ],
+    });
+
+    // Variable: 0.05 * 2.4 * 120 = 14.4 per unit, constant
+    // Fixed: 5000 / quantity
+    const qty100 = evaluateTemplate(template, undefined, 100);
+    expect(qty100.unitPrice).toBeCloseTo(14.4 + 50); // 5000/100 = 50 → 64.4
+    expect(qty100.breakdown.find((b) => b.id === "bd_mat")!.value).toBeCloseTo(14.4);
+    expect(qty100.breakdown.find((b) => b.id === "bd_lab")!.value).toBeCloseTo(50);
+
+    const qty1000 = evaluateTemplate(template, undefined, 1000);
+    expect(qty1000.unitPrice).toBeCloseTo(14.4 + 5); // 5000/1000 = 5 → 19.4
+    expect(qty1000.breakdown.find((b) => b.id === "bd_mat")!.value).toBeCloseTo(14.4);
+    expect(qty1000.breakdown.find((b) => b.id === "bd_lab")!.value).toBeCloseTo(5);
+
+    // As quantity 10×'s, the fixed portion drops 10× while variable stays
+    const qty10000 = evaluateTemplate(template, undefined, 10000);
+    expect(qty10000.unitPrice).toBeCloseTo(14.4 + 0.5); // 14.9
+
+    // Sanity: variable share is identical regardless of quantity
+    expect(qty100.breakdown.find((b) => b.id === "bd_mat")!.value).toBe(
+      qty10000.breakdown.find((b) => b.id === "bd_mat")!.value
+    );
+  });
+
+  it("crew hours amortised across quantity: labour-style fixed cost", () => {
+    // A 40-hour crew day costed at $80/hr = $3200, spread across the row's
+    // quantity. This mirrors the real "labour cost per unit decreases as
+    // quantity increases" pattern used in production templates.
+    const template = tmpl({
+      parameterDefs: [
+        { id: "crew_hours", label: "Crew Hours", defaultValue: 40 },
+        { id: "crew_rate", label: "Crew $/hr", defaultValue: 80 },
+      ],
+      formulaSteps: [
+        // Per-unit labour = (hours * rate) / quantity
+        { id: "labour_per_unit", formula: "(crew_hours * crew_rate) / quantity" },
+      ],
+      breakdownDefs: [
+        {
+          id: "bd1",
+          label: "Labour",
+          items: [{ stepId: "labour_per_unit", label: "Labour" }],
+        },
+      ],
+    });
+
+    // $3200 total labour. Small job (qty 100) = $32/unit. Big job (qty 3200) = $1/unit.
+    expect(evaluateTemplate(template, undefined, 100).unitPrice).toBe(32);
+    expect(evaluateTemplate(template, undefined, 800).unitPrice).toBe(4);
+    expect(evaluateTemplate(template, undefined, 3200).unitPrice).toBe(1);
+  });
+});

--- a/client/src/components/pages/developer/CalculatorCanvas/RateBuildupInputs.tsx
+++ b/client/src/components/pages/developer/CalculatorCanvas/RateBuildupInputs.tsx
@@ -427,6 +427,7 @@ const GroupSection: React.FC<GroupSectionProps> = ({
         {/* Activation toggle — inline in header */}
         {activationCtrl?.type === "toggle" && (
           <Box
+            data-testid={`group-toggle-${group.id}`}
             onClick={(e) => {
               e.stopPropagation();
               onControllerChange(activationCtrl.id, !(controllers[activationCtrl.id] as boolean));

--- a/client/src/components/pages/developer/CalculatorCanvas/RateBuildupInputs.tsx
+++ b/client/src/components/pages/developer/CalculatorCanvas/RateBuildupInputs.tsx
@@ -3,9 +3,10 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Box, Flex, Grid, Input, Popover, PopoverBody, PopoverContent, PopoverTrigger, Select, Text, Textarea } from "@chakra-ui/react";
 import { FiChevronDown, FiChevronRight, FiMessageSquare, FiPlus } from "react-icons/fi";
 import katex from "katex";
-import { CanvasDocument, GroupDef, ControllerDef, isGroupActive, computeInactiveNodeIds } from "./canvasStorage";
+import { CanvasDocument, GroupDef, ControllerDef, isGroupActive } from "./canvasStorage";
+import { evaluateCanvasDoc } from "./snapshotEvaluator";
 import { RateEntry } from "../../../../components/TenderPricing/calculators/types";
-import { evaluateTemplate, debugEvaluateTemplate, evaluateExpression } from "../../../../components/TenderPricing/calculators/evaluate";
+import { debugEvaluateTemplate } from "../../../../components/TenderPricing/calculators/evaluate";
 import { RateRow } from "../../../../components/TenderPricing/calculatorShared";
 import { formulaToLatex } from "./formulaToLatex";
 import { unitLabel } from "../../../../constants/units";
@@ -917,34 +918,14 @@ const RateBuildupInputs: React.FC<RateBuildupInputsProps> = ({
 }) => {
   const inputs = useMemo(() => ({ params, tables }), [params, tables]);
 
-  const controllerValues = useMemo<Record<string, number>>(() => {
-    const result: Record<string, number> = {};
-    for (const c of (doc.controllerDefs ?? [])) {
-      if (c.type === "percentage") result[c.id] = controllers[c.id] as number ?? 0;
-      if (c.type === "toggle") result[c.id] = (controllers[c.id] as boolean) ? 1 : 0;
-    }
-    return result;
-  }, [doc.controllerDefs, controllers]);
-
-  const inactiveNodeIds = useMemo(
-    () => computeInactiveNodeIds(doc, controllers, unit),
-    [doc, controllers, unit]
-  );
-
-  const normalizedQuantity = useMemo(() => {
-    if (!unit || !doc.unitVariants?.length) return quantity;
-    const variant = doc.unitVariants.find((v) => v.unit === unit);
-    if (!variant?.conversionFormula) return quantity;
-    const ctx: Record<string, number> = { quantity };
-    for (const p of doc.parameterDefs) ctx[p.id] = params[p.id] ?? p.defaultValue;
-    const converted = evaluateExpression(variant.conversionFormula, ctx);
-    return converted !== null && converted > 0 ? converted : quantity;
-  }, [unit, doc.unitVariants, doc.parameterDefs, quantity, params]);
-
-  const result = useMemo(
-    () => evaluateTemplate(doc, inputs, normalizedQuantity, controllerValues, inactiveNodeIds),
-    [doc, inputs, normalizedQuantity, controllerValues, inactiveNodeIds]
-  );
+  // Single source of truth for the live-preview compute. Shares
+  // evaluateCanvasDoc with evaluateSnapshot (save path) so the two cannot
+  // drift. See snapshotEvaluator.ts for the rationale.
+  const { result, normalizedQuantity, controllerNumeric, inactiveNodeIds } =
+    useMemo(
+      () => evaluateCanvasDoc(doc, params, tables, controllers, quantity, unit),
+      [doc, params, tables, controllers, quantity, unit]
+    );
 
   const onResultRef = useRef(onResult);
   onResultRef.current = onResult;
@@ -954,11 +935,14 @@ const RateBuildupInputs: React.FC<RateBuildupInputsProps> = ({
 
   const [outputsOpen, setOutputsOpen] = useState(false);
 
-  // Map of formula step id → { label, value, formula } for all active, non-errored steps
+  // Map of formula step id → { label, value, formula } for all active, non-errored steps.
+  // Uses the same normalizedQuantity + controllerNumeric + inactiveNodeIds that
+  // the main result memo computed via evaluateCanvasDoc, so the debug panel
+  // and the main result can never disagree on their inputs.
   const formulaOutputMap = useMemo<Record<string, { label: string; value: number; formula: string }>>(() => {
     if (!doc.formulaSteps.length) return {};
     const stepMeta = new Map(doc.formulaSteps.map((s) => [s.id, { label: s.label ?? s.id, formula: s.formula }]));
-    const stepResults = debugEvaluateTemplate(doc, inputs, normalizedQuantity, controllerValues, inactiveNodeIds);
+    const stepResults = debugEvaluateTemplate(doc, inputs, normalizedQuantity, controllerNumeric, inactiveNodeIds);
     const map: Record<string, { label: string; value: number; formula: string }> = {};
     for (const s of stepResults) {
       const meta = stepMeta.get(s.id);
@@ -967,7 +951,7 @@ const RateBuildupInputs: React.FC<RateBuildupInputsProps> = ({
       }
     }
     return map;
-  }, [doc, inputs, normalizedQuantity, controllerValues, inactiveNodeIds]);
+  }, [doc, inputs, normalizedQuantity, controllerNumeric, inactiveNodeIds]);
 
   // id → label for all variables in scope (used by formulaToLatex inside FormulaOutputRow)
   const variableLabelMap = useMemo<Record<string, string>>(() => {
@@ -979,7 +963,9 @@ const RateBuildupInputs: React.FC<RateBuildupInputsProps> = ({
     return map;
   }, [doc]);
 
-  // id → current numeric value for all variables (used in the variable breakdown table)
+  // id → current numeric value for all variables (used in the variable breakdown table).
+  // Controller values come from the shared controllerNumeric map so the
+  // debug table shows the exact values that went into the formula context.
   const variableValueMap = useMemo<Record<string, number>>(() => {
     const map: Record<string, number> = { quantity: normalizedQuantity };
     for (const p of doc.parameterDefs) map[p.id] = params[p.id] ?? p.defaultValue;
@@ -988,12 +974,9 @@ const RateBuildupInputs: React.FC<RateBuildupInputsProps> = ({
       map[`${t.id}RatePerHr`] = rows.reduce((s, r) => s + r.qty * r.ratePerHour, 0);
     }
     for (const [id, out] of Object.entries(formulaOutputMap)) map[id] = out.value;
-    for (const c of (doc.controllerDefs ?? [])) {
-      if (c.type === "percentage") map[c.id] = controllers[c.id] as number ?? 0;
-      if (c.type === "toggle") map[c.id] = (controllers[c.id] as boolean) ? 1 : 0;
-    }
+    for (const [id, v] of Object.entries(controllerNumeric)) map[id] = v;
     return map;
-  }, [doc, params, tables, normalizedQuantity, formulaOutputMap, controllers]);
+  }, [doc, params, tables, normalizedQuantity, formulaOutputMap, controllerNumeric]);
 
   // Ungrouped formula outputs (not a member of any group)
   const ungroupedFormulaOutputs = useMemo(() => {

--- a/client/src/components/pages/developer/CalculatorCanvas/__tests__/fragmentParser.test.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/__tests__/fragmentParser.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import { fragmentToDoc } from "../fragmentParser";
+
+// Fragments come from Apollo as loosely-typed objects. Tests cast as any to
+// avoid importing the full generated fragment type (stubbed in vitest config).
+const frag = (overrides: Record<string, any> = {}): any => ({
+  _id: "tmpl_1",
+  label: "Test",
+  defaultUnit: "m2",
+  parameterDefs: [],
+  tableDefs: [],
+  formulaSteps: [],
+  breakdownDefs: [],
+  outputDefs: [],
+  groupDefs: [],
+  controllerDefs: [],
+  unitVariants: [],
+  updatedAt: null,
+  specialPositions: null,
+  ...overrides,
+});
+
+describe("fragmentToDoc", () => {
+  describe("happy path", () => {
+    it("maps minimal fragment to a CanvasDocument", () => {
+      const doc = fragmentToDoc(frag());
+      expect(doc.id).toBe("tmpl_1");
+      expect(doc.label).toBe("Test");
+      expect(doc.defaultUnit).toBe("m2");
+      expect(doc.parameterDefs).toEqual([]);
+      expect(doc.groupDefs).toEqual([]);
+      expect(doc.controllerDefs).toEqual([]);
+      expect(doc.unitVariants).toEqual([]);
+    });
+
+    it("uses 'unit' fallback when defaultUnit is null", () => {
+      const doc = fragmentToDoc(frag({ defaultUnit: null }));
+      expect(doc.defaultUnit).toBe("unit");
+    });
+  });
+
+  describe("specialPositions", () => {
+    it("parses JSON string form", () => {
+      const doc = fragmentToDoc(
+        frag({
+          specialPositions: JSON.stringify({
+            quantity: { x: 50, y: 60 },
+            unitPrice: { x: 500, y: 600 },
+          }),
+        })
+      );
+      expect(doc.specialPositions.quantity).toEqual({ x: 50, y: 60 });
+      expect(doc.specialPositions.unitPrice).toEqual({ x: 500, y: 600 });
+    });
+
+    it("accepts pre-parsed object form", () => {
+      const doc = fragmentToDoc(
+        frag({
+          specialPositions: {
+            quantity: { x: 10, y: 20 },
+            unitPrice: { x: 30, y: 40 },
+          },
+        })
+      );
+      expect(doc.specialPositions.quantity).toEqual({ x: 10, y: 20 });
+      expect(doc.specialPositions.unitPrice).toEqual({ x: 30, y: 40 });
+    });
+
+    it("falls back to defaults on invalid JSON", () => {
+      const doc = fragmentToDoc(frag({ specialPositions: "{broken json" }));
+      expect(doc.specialPositions.quantity).toEqual({ x: 100, y: 200 });
+      expect(doc.specialPositions.unitPrice).toEqual({ x: 700, y: 200 });
+    });
+
+    it("uses defaults when specialPositions is null", () => {
+      const doc = fragmentToDoc(frag({ specialPositions: null }));
+      expect(doc.specialPositions.quantity).toEqual({ x: 100, y: 200 });
+      expect(doc.specialPositions.unitPrice).toEqual({ x: 700, y: 200 });
+    });
+
+    it("partial specialPositions keeps defaults for missing keys", () => {
+      const doc = fragmentToDoc(
+        frag({ specialPositions: JSON.stringify({ quantity: { x: 11, y: 22 } }) })
+      );
+      expect(doc.specialPositions.quantity).toEqual({ x: 11, y: 22 });
+      // unitPrice default retained
+      expect(doc.specialPositions.unitPrice).toEqual({ x: 700, y: 200 });
+    });
+  });
+
+  describe("groupDefs legacy parsing", () => {
+    it("accepts typed array form", () => {
+      const groups = [
+        { id: "g1", label: "G1", memberIds: ["a", "b"], position: { x: 0, y: 0 } },
+      ];
+      const doc = fragmentToDoc(frag({ groupDefs: groups }));
+      expect(doc.groupDefs).toHaveLength(1);
+      expect(doc.groupDefs[0].id).toBe("g1");
+    });
+
+    it("parses JSON string (pre-migration form)", () => {
+      const doc = fragmentToDoc(
+        frag({
+          groupDefs: JSON.stringify([
+            { id: "g1", label: "G", memberIds: ["x"], position: { x: 0, y: 0 } },
+          ]),
+        })
+      );
+      expect(doc.groupDefs).toHaveLength(1);
+      expect(doc.groupDefs[0].memberIds).toEqual(["x"]);
+    });
+
+    it("empty on invalid groupDefs JSON", () => {
+      const doc = fragmentToDoc(frag({ groupDefs: "{broken" }));
+      expect(doc.groupDefs).toEqual([]);
+    });
+
+    it("deduplicates memberIds within a group", () => {
+      const doc = fragmentToDoc(
+        frag({
+          groupDefs: [
+            { id: "g1", label: "G", memberIds: ["a", "b", "a", "c", "b"], position: { x: 0, y: 0 } },
+          ],
+        })
+      );
+      expect(doc.groupDefs[0].memberIds).toEqual(["a", "b", "c"]);
+    });
+  });
+
+  describe("controllerDefs legacy parsing", () => {
+    it("accepts typed array form", () => {
+      const doc = fragmentToDoc(
+        frag({
+          controllerDefs: [
+            { id: "c1", label: "C", type: "percentage", defaultValue: 0.1, position: { x: 0, y: 0 } },
+          ],
+        })
+      );
+      expect(doc.controllerDefs).toHaveLength(1);
+    });
+
+    it("parses JSON string (pre-migration form)", () => {
+      const doc = fragmentToDoc(
+        frag({
+          controllerDefs: JSON.stringify([
+            { id: "c1", label: "C", type: "toggle", defaultValue: true, position: { x: 0, y: 0 } },
+          ]),
+        })
+      );
+      expect(doc.controllerDefs).toHaveLength(1);
+      expect(doc.controllerDefs[0].type).toBe("toggle");
+    });
+
+    it("empty on invalid controllerDefs JSON", () => {
+      const doc = fragmentToDoc(frag({ controllerDefs: "not json" }));
+      expect(doc.controllerDefs).toEqual([]);
+    });
+  });
+
+  describe("canvas def dedup by id", () => {
+    it("drops duplicate parameterDefs by id, keeping first", () => {
+      const pos = { x: 0, y: 0 };
+      const doc = fragmentToDoc(
+        frag({
+          parameterDefs: [
+            { id: "p1", label: "First", defaultValue: 1, position: pos },
+            { id: "p1", label: "Dup", defaultValue: 2, position: pos },
+            { id: "p2", label: "Second", defaultValue: 3, position: pos },
+          ],
+        })
+      );
+      expect(doc.parameterDefs).toHaveLength(2);
+      expect(doc.parameterDefs[0].label).toBe("First");
+      expect(doc.parameterDefs[1].id).toBe("p2");
+    });
+
+    it("dedups tableDefs, formulaSteps, breakdownDefs, outputDefs", () => {
+      const pos = { x: 0, y: 0 };
+      const doc = fragmentToDoc(
+        frag({
+          tableDefs: [
+            { id: "t1", label: "T", rowLabel: "R", defaultRows: [], position: pos },
+            { id: "t1", label: "Dup", rowLabel: "R", defaultRows: [], position: pos },
+          ],
+          formulaSteps: [
+            { id: "f1", formula: "1", position: pos },
+            { id: "f1", formula: "2", position: pos },
+          ],
+          breakdownDefs: [
+            { id: "b1", label: "B", items: [], position: pos },
+            { id: "b1", label: "Dup", items: [], position: pos },
+          ],
+          outputDefs: [
+            { id: "o1", kind: "Material", sourceStepId: "f1", unit: "t", position: pos },
+            { id: "o1", kind: "CrewHours", sourceStepId: "f1", unit: "hr", position: pos },
+          ],
+        })
+      );
+      expect(doc.tableDefs).toHaveLength(1);
+      expect(doc.formulaSteps).toHaveLength(1);
+      expect(doc.formulaSteps[0].formula).toBe("1");
+      expect(doc.breakdownDefs).toHaveLength(1);
+      expect(doc.outputDefs).toHaveLength(1);
+      expect(doc.outputDefs[0].kind).toBe("Material"); // first wins
+    });
+  });
+
+  describe("unitVariants", () => {
+    it("strips null conversionFormula", () => {
+      const doc = fragmentToDoc(
+        frag({
+          unitVariants: [
+            { unit: "m2", activatesGroupId: "g_m2", conversionFormula: null },
+            { unit: "m3", activatesGroupId: "g_m3", conversionFormula: "quantity / depth" },
+          ],
+        })
+      );
+      expect(doc.unitVariants).toHaveLength(2);
+      expect(doc.unitVariants![0].conversionFormula).toBeUndefined();
+      expect(doc.unitVariants![1].conversionFormula).toBe("quantity / depth");
+    });
+  });
+});

--- a/client/src/components/pages/developer/CalculatorCanvas/__tests__/snapshotEvaluator.test.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/__tests__/snapshotEvaluator.test.ts
@@ -738,3 +738,89 @@ describe("evaluateSnapshot — multi-output templates", () => {
     );
   });
 });
+
+// ─── Unit variant × controller interaction ──────────────────────────────────
+
+describe("evaluateSnapshot — unit variant × controller interaction", () => {
+  // Template with BOTH a unit variant group AND an independent controller group.
+  // Scenarios: variant m2 OR m3, and controller waste toggle on/off.
+  // Must correctly combine: only the matching variant group active AND the
+  // waste group active iff controller value matches activation condition.
+  function makeTemplate() {
+    return doc({
+      parameterDefs: [
+        { id: "depth_m", label: "Depth", defaultValue: 0.05, position: pos },
+      ],
+      controllerDefs: [
+        { id: "waste", label: "Waste", type: "toggle", defaultValue: false, position: pos },
+      ],
+      formulaSteps: [
+        // m2 base: quantity * 10
+        { id: "baseM2", formula: "quantity * 10", position: pos },
+        // m3 base: quantity * 1000 (area conversion built into variant formula)
+        { id: "baseM3", formula: "quantity * 1000", position: pos },
+        // Waste add-on: quantity * 1 (active only when waste toggle on)
+        { id: "wasteCost", formula: "quantity * 1", position: pos },
+      ],
+      breakdownDefs: [
+        {
+          id: "bd1",
+          label: "T",
+          items: [
+            { stepId: "baseM2", label: "Base m2" },
+            { stepId: "baseM3", label: "Base m3" },
+            { stepId: "wasteCost", label: "Waste" },
+          ],
+          position: pos,
+        },
+      ],
+      unitVariants: [
+        { unit: "m2", activatesGroupId: "g_m2" },
+        { unit: "m3", activatesGroupId: "g_m3", conversionFormula: "quantity / depth_m" },
+      ],
+      groupDefs: [
+        { id: "g_m2", label: "m2 branch", memberIds: ["baseM2"], position: pos },
+        { id: "g_m3", label: "m3 branch", memberIds: ["baseM3"], position: pos },
+        {
+          id: "g_waste",
+          label: "Waste",
+          memberIds: ["wasteCost"],
+          activation: { controllerId: "waste", condition: "=== 1" },
+          position: pos,
+        },
+      ],
+    });
+  }
+
+  it("m2 variant + waste off: only baseM2 active", () => {
+    const s = snap(makeTemplate(), { controllers: { waste: false } });
+    // quantity 5 m2 → baseM2 = 50; baseM3 inactive = 0; wasteCost inactive = 0
+    expect(evaluateSnapshot(s, 5, "m2").unitPrice).toBe(50);
+  });
+
+  it("m2 variant + waste on: baseM2 + wasteCost", () => {
+    const s = snap(makeTemplate(), { controllers: { waste: true } });
+    // quantity 5 m2 → baseM2 = 50 + wasteCost = 5 → 55
+    expect(evaluateSnapshot(s, 5, "m2").unitPrice).toBe(55);
+  });
+
+  it("m3 variant + waste off: only baseM3 active, conversion applies", () => {
+    const s = snap(makeTemplate(), { controllers: { waste: false } });
+    // raw 5 m3, depth 0.05 → converted quantity 100
+    // baseM3 = 100 * 1000 = 100000; baseM2 inactive; wasteCost inactive
+    expect(evaluateSnapshot(s, 5, "m3").unitPrice).toBe(100000);
+  });
+
+  it("m3 variant + waste on: baseM3 + wasteCost, conversion applies to both", () => {
+    const s = snap(makeTemplate(), { controllers: { waste: true } });
+    // converted quantity 100 → baseM3 100000 + wasteCost 100 → 100100
+    expect(evaluateSnapshot(s, 5, "m3").unitPrice).toBe(100100);
+  });
+
+  it("no unit specified: all variant groups inactive, controller group still honored", () => {
+    const s = snap(makeTemplate(), { controllers: { waste: true } });
+    // No unit → both m2 and m3 variant groups inactive. Only wasteCost active.
+    // quantity 5 → wasteCost = 5
+    expect(evaluateSnapshot(s, 5).unitPrice).toBe(5);
+  });
+});

--- a/client/src/components/pages/developer/CalculatorCanvas/__tests__/snapshotEvaluator.test.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/__tests__/snapshotEvaluator.test.ts
@@ -910,3 +910,133 @@ describe("evaluateSnapshot — quantity-dependent unit price", () => {
     expect(evaluateSnapshot(s, 1000).unitPrice).toBeCloseTo(19.2);
   });
 });
+
+// ─── Regression: controllers referenced in formulas ─────────────────────────
+//
+// Prod bug (caught via kubectl logs on 2026-04-13): when a template defines
+// controllers and references them in formula steps (e.g., `base * waste_pct`
+// or `base + labour_toggle * 100`), but the saved snapshot's `controllers`
+// object is empty (user never touched the inputs), `evaluateSnapshot` used
+// to build `controllerNumeric` from `Object.entries(snapshot.controllers)`
+// — which skipped every defined controller. Formulas then failed to resolve
+// the controller variable and safeEval returned 0 for the whole step.
+// Meanwhile RateBuildupInputs' live preview built its context from
+// `doc.controllerDefs`, so the displayed unit price was correct while the
+// persisted one was silently wrong — visible only after reload.
+//
+// The fix: iterate `doc.controllerDefs` and seed defaults for unset keys.
+// These tests guarantee the two code paths agree on the same inputs.
+
+describe("evaluateSnapshot — formulas referencing controllers with empty snapshot.controllers", () => {
+  function templateWithControllerInFormula() {
+    return doc({
+      parameterDefs: [
+        { id: "base_rate", label: "Base", defaultValue: 100, position: pos },
+      ],
+      controllerDefs: [
+        { id: "waste_pct", label: "Waste %", type: "percentage", defaultValue: 0.1, position: pos },
+        { id: "hazard_on", label: "Hazard", type: "toggle", defaultValue: true, position: pos },
+      ],
+      formulaSteps: [
+        // Formula references BOTH controllers by id — this is the scenario
+        // where the old evaluator collapsed to 0 when snapshot.controllers was empty.
+        { id: "total", formula: "base_rate * (1 + waste_pct) + hazard_on * 50", position: pos },
+      ],
+      breakdownDefs: [
+        {
+          id: "bd1",
+          label: "Total",
+          items: [{ stepId: "total", label: "Total" }],
+          position: pos,
+        },
+      ],
+    });
+  }
+
+  it("uses controllerDef defaults when snapshot.controllers is empty", () => {
+    const template = templateWithControllerInFormula();
+    // Explicitly empty snapshot.controllers — the user never edited them.
+    const s = snap(template, { controllers: {} });
+
+    // Expected: base_rate=100, waste_pct default 0.1, hazard_on default true→1
+    // total = 100 * (1 + 0.1) + 1 * 50 = 110 + 50 = 160
+    expect(evaluateSnapshot(s, 1).unitPrice).toBeCloseTo(160, 2);
+  });
+
+  it("uses controllerDef defaults for percentage controller with no defaultValue", () => {
+    // A percentage controller with NO defaultValue on the def should seed 0.
+    const template = doc({
+      controllerDefs: [
+        { id: "markup_pct", label: "Markup %", type: "percentage", position: pos },
+      ],
+      formulaSteps: [
+        { id: "total", formula: "100 + markup_pct * 100", position: pos },
+      ],
+      breakdownDefs: [
+        {
+          id: "bd1",
+          label: "T",
+          items: [{ stepId: "total", label: "T" }],
+          position: pos,
+        },
+      ],
+    });
+    const s = snap(template, { controllers: {} });
+    // markup_pct = 0 (no default) → total = 100 + 0 = 100
+    expect(evaluateSnapshot(s, 1).unitPrice).toBeCloseTo(100, 2);
+  });
+
+  it("uses controllerDef false default for toggle with no defaultValue", () => {
+    const template = doc({
+      controllerDefs: [
+        { id: "extra_fee", label: "Extra", type: "toggle", position: pos },
+      ],
+      formulaSteps: [
+        { id: "total", formula: "100 + extra_fee * 25", position: pos },
+      ],
+      breakdownDefs: [
+        {
+          id: "bd1",
+          label: "T",
+          items: [{ stepId: "total", label: "T" }],
+          position: pos,
+        },
+      ],
+    });
+    const s = snap(template, { controllers: {} });
+    // extra_fee defaultValue undefined → 0 → total = 100
+    expect(evaluateSnapshot(s, 1).unitPrice).toBeCloseTo(100, 2);
+  });
+
+  it("snapshot.controllers values override controllerDef defaults", () => {
+    const template = templateWithControllerInFormula();
+    // Explicit values in snapshot — should win over def defaults.
+    const s = snap(template, {
+      controllers: { waste_pct: 0.25, hazard_on: false },
+    });
+    // total = 100 * (1 + 0.25) + 0 * 50 = 125
+    expect(evaluateSnapshot(s, 1).unitPrice).toBeCloseTo(125, 2);
+  });
+
+  it("does not crash when formula references a controller absent from the def list", () => {
+    // Defensive: formula mentions `ghost_ctrl` which doesn't exist. safeEval
+    // still collapses to 0 for that step, but the evaluator must not throw.
+    const template = doc({
+      controllerDefs: [],
+      formulaSteps: [
+        { id: "total", formula: "100 + ghost_ctrl * 5", position: pos },
+      ],
+      breakdownDefs: [
+        {
+          id: "bd1",
+          label: "T",
+          items: [{ stepId: "total", label: "T" }],
+          position: pos,
+        },
+      ],
+    });
+    const s = snap(template, { controllers: {} });
+    // total safeEval → throws on undefined var → returns 0
+    expect(evaluateSnapshot(s, 1).unitPrice).toBe(0);
+  });
+});

--- a/client/src/components/pages/developer/CalculatorCanvas/__tests__/snapshotEvaluator.test.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/__tests__/snapshotEvaluator.test.ts
@@ -824,3 +824,89 @@ describe("evaluateSnapshot — unit variant × controller interaction", () => {
     expect(evaluateSnapshot(s, 5).unitPrice).toBe(5);
   });
 });
+
+// ─── Fixed-cost-per-unit through full snapshot path ─────────────────────────
+//
+// Production templates commonly have labour/setup costs that are fixed across
+// a row, expressed as `lump_sum / quantity` in the formula. As quantity grows,
+// per-unit price drops. These tests drive that pattern through evaluateSnapshot
+// (not just evaluateTemplate) so we verify the full snapshot → evaluator path.
+
+describe("evaluateSnapshot — quantity-dependent unit price", () => {
+  function fixedCostTemplate() {
+    return doc({
+      parameterDefs: [
+        { id: "depth_m", label: "Depth", defaultValue: 0.05, position: pos },
+        { id: "density", label: "Density", defaultValue: 2.4, position: pos },
+        { id: "price_per_t", label: "$/t", defaultValue: 120, position: pos },
+        { id: "crew_hours", label: "Crew Hours", defaultValue: 40, position: pos },
+        { id: "crew_rate", label: "Crew $/hr", defaultValue: 80, position: pos },
+      ],
+      formulaSteps: [
+        // Variable per-unit: depth * density * $/t  (no quantity)
+        { id: "mat_per_unit", formula: "depth_m * density * price_per_t", position: pos },
+        // Fixed per-unit: (hours * rate) / quantity
+        { id: "lab_per_unit", formula: "(crew_hours * crew_rate) / quantity", position: pos },
+      ],
+      breakdownDefs: [
+        {
+          id: "bd_mat",
+          label: "Material",
+          items: [{ stepId: "mat_per_unit", label: "Material" }],
+          position: pos,
+        },
+        {
+          id: "bd_lab",
+          label: "Labour",
+          items: [{ stepId: "lab_per_unit", label: "Labour" }],
+          position: pos,
+        },
+      ],
+    });
+  }
+
+  it("small quantity: fixed labour dominates unit price", () => {
+    const s = snap(fixedCostTemplate());
+    // material 14.4/unit + labour (40*80)/100 = 32/unit → 46.4
+    expect(evaluateSnapshot(s, 100).unitPrice).toBeCloseTo(46.4);
+  });
+
+  it("medium quantity: fixed labour share drops", () => {
+    const s = snap(fixedCostTemplate());
+    // 14.4 + 3200/1000 = 14.4 + 3.2 = 17.6
+    expect(evaluateSnapshot(s, 1000).unitPrice).toBeCloseTo(17.6);
+  });
+
+  it("large quantity: per-unit approaches variable cost only", () => {
+    const s = snap(fixedCostTemplate());
+    // 14.4 + 3200/10000 = 14.4 + 0.32 = 14.72
+    expect(evaluateSnapshot(s, 10000).unitPrice).toBeCloseTo(14.72);
+  });
+
+  it("doubling quantity halves the fixed-cost portion but keeps variable constant", () => {
+    const s = snap(fixedCostTemplate());
+    // Variable: 14.4 constant
+    // Fixed at 500: 3200/500 = 6.4 → total 20.8
+    // Fixed at 1000: 3200/1000 = 3.2 → total 17.6
+    // Delta = 20.8 - 17.6 = 3.2 (exactly half of 6.4)
+    const small = evaluateSnapshot(s, 500).unitPrice;
+    const big = evaluateSnapshot(s, 1000).unitPrice;
+    expect(small - big).toBeCloseTo(3.2);
+  });
+
+  it("estimator overrides labour lump via snapshot params, price reflects it", () => {
+    // Real-world: estimator edits crew_hours from 40 to 60 for a harder site.
+    // Fixed portion grows proportionally.
+    const s = snap(fixedCostTemplate(), {
+      params: {
+        depth_m: 0.05,
+        density: 2.4,
+        price_per_t: 120,
+        crew_hours: 60, // bumped from 40
+        crew_rate: 80,
+      },
+    });
+    // labour lump = 60*80 = 4800. At qty 1000: 4.8/unit. Total: 14.4 + 4.8 = 19.2
+    expect(evaluateSnapshot(s, 1000).unitPrice).toBeCloseTo(19.2);
+  });
+});

--- a/client/src/components/pages/developer/CalculatorCanvas/__tests__/snapshotEvaluator.test.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/__tests__/snapshotEvaluator.test.ts
@@ -4,6 +4,7 @@ import {
   evaluateSnapshot,
   computeSnapshotUnitPrice,
   snapshotFromTemplate,
+  snapshotToCanvasDoc,
   RateBuildupSnapshot,
 } from "../snapshotEvaluator";
 import type { CanvasDocument } from "../canvasTypes";
@@ -429,5 +430,193 @@ describe("computeSnapshotUnitPrice", () => {
     expect(unitPrice).toBe(45);
     // Should match evaluateSnapshot result exactly
     expect(unitPrice).toBe(evaluateSnapshot(s, 3).unitPrice);
+  });
+});
+
+// ─── snapshotFromTemplate ────────────────────────────────────────────────────
+
+describe("snapshotFromTemplate", () => {
+  it("seeds params from parameterDef defaultValue", () => {
+    const template = doc({
+      parameterDefs: [
+        { id: "rate", label: "Rate", defaultValue: 120, position: pos },
+        { id: "depth", label: "Depth", defaultValue: 0.05, position: pos },
+      ],
+    });
+    const s = snapshotFromTemplate(template);
+    expect(s.params.rate).toBe(120);
+    expect(s.params.depth).toBe(0.05);
+  });
+
+  it("seeds tables from tableDef defaultRows", () => {
+    const template = doc({
+      tableDefs: [
+        {
+          id: "crew",
+          label: "Crew",
+          rowLabel: "Role",
+          defaultRows: [
+            { id: "r1", name: "Operator", qty: 1, ratePerHour: 80 },
+            { id: "r2", name: "Labour", qty: 2, ratePerHour: 50 },
+          ],
+          position: pos,
+        },
+      ],
+    });
+    const s = snapshotFromTemplate(template);
+    expect(s.tables.crew).toHaveLength(2);
+    expect(s.tables.crew[0].ratePerHour).toBe(80);
+  });
+
+  it("defaults tableDef without defaultRows to empty array", () => {
+    const template = doc({
+      tableDefs: [
+        { id: "t1", label: "T", rowLabel: "R", defaultRows: undefined as any, position: pos },
+      ],
+    });
+    const s = snapshotFromTemplate(template);
+    expect(s.tables.t1).toEqual([]);
+  });
+
+  it("seeds percentage controller with numeric default", () => {
+    const template = doc({
+      controllerDefs: [
+        { id: "waste", label: "Waste", type: "percentage", defaultValue: 0.1, position: pos },
+      ],
+    });
+    const s = snapshotFromTemplate(template);
+    expect(s.controllers.waste).toBe(0.1);
+  });
+
+  it("seeds percentage controller with 0 when default missing", () => {
+    const template = doc({
+      controllerDefs: [
+        { id: "waste", label: "Waste", type: "percentage", position: pos },
+      ],
+    });
+    const s = snapshotFromTemplate(template);
+    expect(s.controllers.waste).toBe(0);
+  });
+
+  it("seeds toggle controller with boolean default", () => {
+    const template = doc({
+      controllerDefs: [
+        { id: "sealcoat", label: "Sealcoat", type: "toggle", defaultValue: true, position: pos },
+      ],
+    });
+    const s = snapshotFromTemplate(template);
+    expect(s.controllers.sealcoat).toBe(true);
+  });
+
+  it("seeds toggle controller with false when default missing", () => {
+    const template = doc({
+      controllerDefs: [
+        { id: "sealcoat", label: "Sealcoat", type: "toggle", position: pos },
+      ],
+    });
+    const s = snapshotFromTemplate(template);
+    expect(s.controllers.sealcoat).toBe(false);
+  });
+
+  it("seeds selector controller with defaultSelected", () => {
+    const template = doc({
+      controllerDefs: [
+        {
+          id: "mix",
+          label: "Mix",
+          type: "selector",
+          options: [
+            { id: "opt_a", label: "A" },
+            { id: "opt_b", label: "B" },
+          ],
+          defaultSelected: ["opt_a"],
+          position: pos,
+        },
+      ],
+    });
+    const s = snapshotFromTemplate(template);
+    expect(s.controllers.mix).toEqual(["opt_a"]);
+  });
+
+  it("seeds selector controller with empty array when defaultSelected missing", () => {
+    const template = doc({
+      controllerDefs: [
+        { id: "mix", label: "Mix", type: "selector", position: pos },
+      ],
+    });
+    const s = snapshotFromTemplate(template);
+    expect(s.controllers.mix).toEqual([]);
+  });
+
+  it("seeds Material output selection from defaultMaterialId", () => {
+    const template = doc({
+      outputDefs: [
+        {
+          id: "out1",
+          kind: RateBuildupOutputKind.Material,
+          sourceStepId: "step1",
+          unit: "t",
+          defaultMaterialId: "mat_default",
+          position: pos,
+        },
+      ],
+    });
+    const s = snapshotFromTemplate(template);
+    expect(s.outputs!.out1).toEqual({ materialId: "mat_default" });
+  });
+
+  it("seeds CrewHours output selection from defaultCrewKindId", () => {
+    const template = doc({
+      outputDefs: [
+        {
+          id: "out1",
+          kind: RateBuildupOutputKind.CrewHours,
+          sourceStepId: "step1",
+          unit: "hr",
+          defaultCrewKindId: "ck_base",
+          position: pos,
+        },
+      ],
+    });
+    const s = snapshotFromTemplate(template);
+    expect(s.outputs!.out1).toEqual({ crewKindId: "ck_base" });
+  });
+
+  it("sourceTemplateId matches template id", () => {
+    const template = doc({ id: "tmpl_xyz" });
+    const s = snapshotFromTemplate(template);
+    expect(s.sourceTemplateId).toBe("tmpl_xyz");
+  });
+});
+
+// ─── snapshotToCanvasDoc ─────────────────────────────────────────────────────
+
+describe("snapshotToCanvasDoc", () => {
+  it("strips snapshot-specific fields and returns the canvas shape", () => {
+    const template = doc({
+      parameterDefs: [{ id: "rate", label: "Rate", defaultValue: 20, position: pos }],
+    });
+    const s = snapshotFromTemplate(template);
+    s.paramNotes = { rate: "confirmed with estimator" };
+
+    const back = snapshotToCanvasDoc(s);
+    expect(back.parameterDefs).toEqual(template.parameterDefs);
+    expect((back as any).params).toBeUndefined();
+    expect((back as any).tables).toBeUndefined();
+    expect((back as any).controllers).toBeUndefined();
+    expect((back as any).paramNotes).toBeUndefined();
+    expect((back as any).outputs).toBeUndefined();
+    expect((back as any).sourceTemplateId).toBeUndefined();
+  });
+
+  it("legacy fallback: provides empty outputDefs when snapshot has none", () => {
+    // Older snapshots saved before outputDefs were introduced. Simulate by
+    // building a snapshot then deleting outputDefs to match stored shape.
+    const template = doc();
+    const s = snapshotFromTemplate(template);
+    delete (s as any).outputDefs;
+
+    const back = snapshotToCanvasDoc(s);
+    expect(back.outputDefs).toEqual([]);
   });
 });

--- a/client/src/components/pages/developer/CalculatorCanvas/__tests__/snapshotEvaluator.test.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/__tests__/snapshotEvaluator.test.ts
@@ -620,3 +620,121 @@ describe("snapshotToCanvasDoc", () => {
     expect(back.outputDefs).toEqual([]);
   });
 });
+
+// ─── Multi-output mixed kinds ────────────────────────────────────────────────
+
+describe("evaluateSnapshot — multi-output templates", () => {
+  it("resolves three outputs of mixed kinds simultaneously", () => {
+    const template = doc({
+      parameterDefs: [
+        { id: "depth_m", label: "Depth", defaultValue: 0.05, position: pos },
+      ],
+      formulaSteps: [
+        // Asphalt tons: quantity * depth * density
+        { id: "tons", formula: "quantity * depth_m * 2.4", position: pos },
+        // Operator hours: 1 hr per 100 m2
+        { id: "opHours", formula: "quantity / 100", position: pos },
+        // Labourer hours: 2x operator
+        { id: "labHours", formula: "opHours * 2", position: pos },
+        // Unit cost from tons at $120/t plus crew
+        { id: "cost", formula: "tons * 120 + opHours * 80 + labHours * 50", position: pos },
+      ],
+      breakdownDefs: [
+        { id: "bd1", label: "Total", items: [{ stepId: "cost", label: "Cost" }], position: pos },
+      ],
+      outputDefs: [
+        {
+          id: "mat_asphalt",
+          kind: RateBuildupOutputKind.Material,
+          sourceStepId: "tons",
+          unit: "t",
+          defaultMaterialId: "mat_asphalt_id",
+          position: pos,
+        },
+        {
+          id: "crew_operator",
+          kind: RateBuildupOutputKind.CrewHours,
+          sourceStepId: "opHours",
+          unit: "hr",
+          defaultCrewKindId: "ck_operator",
+          position: pos,
+        },
+        {
+          id: "crew_labour",
+          kind: RateBuildupOutputKind.CrewHours,
+          sourceStepId: "labHours",
+          unit: "hr",
+          defaultCrewKindId: "ck_labour",
+          position: pos,
+        },
+      ],
+    });
+    const s = snap(template);
+
+    const { unitPrice, outputs } = evaluateSnapshot(s, 1000);
+    // tons = 1000 * 0.05 * 2.4 = 120
+    // opHours = 10
+    // labHours = 20
+    // cost = 120*120 + 10*80 + 20*50 = 14400 + 800 + 1000 = 16200
+    expect(unitPrice).toBe(16200);
+
+    expect(outputs).toHaveLength(3);
+
+    const asphalt = outputs.find((o) => o.materialId === "mat_asphalt_id");
+    expect(asphalt).toBeDefined();
+    expect(asphalt!.kind).toBe(RateBuildupOutputKind.Material);
+    expect(asphalt!.unit).toBe("t");
+    expect(asphalt!.totalValue).toBe(120);
+
+    const operator = outputs.find((o) => o.crewKindId === "ck_operator");
+    expect(operator).toBeDefined();
+    expect(operator!.kind).toBe(RateBuildupOutputKind.CrewHours);
+    expect(operator!.unit).toBe("hr");
+    expect(operator!.totalValue).toBe(10);
+
+    const labour = outputs.find((o) => o.crewKindId === "ck_labour");
+    expect(labour).toBeDefined();
+    expect(labour!.totalValue).toBe(20);
+  });
+
+  it("overrides each output independently via snapshot.outputs", () => {
+    const template = doc({
+      formulaSteps: [
+        { id: "tons", formula: "quantity * 0.1", position: pos },
+        { id: "hours", formula: "quantity * 0.05", position: pos },
+      ],
+      outputDefs: [
+        {
+          id: "mat",
+          kind: RateBuildupOutputKind.Material,
+          sourceStepId: "tons",
+          unit: "t",
+          defaultMaterialId: "mat_default",
+          position: pos,
+        },
+        {
+          id: "crew",
+          kind: RateBuildupOutputKind.CrewHours,
+          sourceStepId: "hours",
+          unit: "hr",
+          defaultCrewKindId: "ck_default",
+          position: pos,
+        },
+      ],
+    });
+    const s = snap(template, {
+      outputs: {
+        mat: { materialId: "mat_picked" },
+        crew: { crewKindId: "ck_picked" },
+      },
+    });
+
+    const { outputs } = evaluateSnapshot(s, 100);
+    expect(outputs.find((o) => o.kind === RateBuildupOutputKind.Material)!.materialId).toBe(
+      "mat_picked"
+    );
+    expect(outputs.find((o) => o.kind === RateBuildupOutputKind.CrewHours)!.crewKindId).toBe(
+      "ck_picked"
+    );
+  });
+});

--- a/client/src/components/pages/developer/CalculatorCanvas/canvasStorage.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/canvasStorage.ts
@@ -48,66 +48,8 @@ export {
 
 // ─── Serialise / deserialise ──────────────────────────────────────────────────
 
-export function fragmentToDoc(f: RateBuildupTemplateFullSnippetFragment): CanvasDocument {
-  const specialPositions: SpecialNodePositions = {
-    quantity: { x: 100, y: 200 },
-    unitPrice: { x: 700, y: 200 },
-  };
-  if (f.specialPositions) {
-    try {
-      const sp = typeof f.specialPositions === "string"
-        ? JSON.parse(f.specialPositions)
-        : f.specialPositions;
-      if (sp?.quantity) specialPositions.quantity = sp.quantity;
-      if (sp?.unitPrice) specialPositions.unitPrice = sp.unitPrice;
-    } catch { /* ignore */ }
-  }
-
-  // groupDefs and controllerDefs arrive as typed sub-docs after server migration;
-  // fall back to parsing JSON strings for pre-migration data.
-  let groupDefs: GroupDef[] = [];
-  if (Array.isArray(f.groupDefs)) {
-    groupDefs = f.groupDefs as GroupDef[];
-  } else if (typeof f.groupDefs === "string") {
-    try { groupDefs = JSON.parse(f.groupDefs); } catch { /* ignore */ }
-  }
-  // Deduplicate memberIds within each group
-  groupDefs = groupDefs.map((g) => ({ ...g, memberIds: [...new Set(g.memberIds)] }));
-
-  let controllerDefs: ControllerDef[] = [];
-  if (Array.isArray(f.controllerDefs)) {
-    controllerDefs = f.controllerDefs as ControllerDef[];
-  } else if (typeof f.controllerDefs === "string") {
-    try { controllerDefs = JSON.parse(f.controllerDefs); } catch { /* ignore */ }
-  }
-
-  // Deduplicate defs by ID — protects against duplicate entries that may have been
-  // saved when the canvas had a bug where content edits didn't visually reflect.
-  const dedup = <T extends { id: string }>(arr: T[]): T[] => {
-    const seen = new Set<string>();
-    return arr.filter((item) => {
-      if (seen.has(item.id)) return false;
-      seen.add(item.id);
-      return true;
-    });
-  };
-
-  return {
-    id: f._id,
-    label: f.label,
-    defaultUnit: f.defaultUnit ?? "unit",
-    parameterDefs: dedup((f.parameterDefs ?? []) as CanvasParameterDef[]),
-    tableDefs: dedup((f.tableDefs ?? []) as CanvasTableDef[]),
-    formulaSteps: dedup((f.formulaSteps ?? []) as CanvasFormulaStep[]),
-    breakdownDefs: dedup((f.breakdownDefs ?? []) as CanvasBreakdownDef[]),
-    outputDefs: dedup(((f.outputDefs ?? []) as OutputDef[])),
-    specialPositions,
-    groupDefs,
-    controllerDefs,
-    unitVariants: (f.unitVariants ?? []).map(({ unit, activatesGroupId, conversionFormula }) => ({ unit, activatesGroupId, conversionFormula: conversionFormula ?? undefined })),
-    updatedAt: f.updatedAt ?? undefined,
-  };
-}
+export { fragmentToDoc } from "./fragmentParser";
+import { fragmentToDoc } from "./fragmentParser";
 
 function omitTypename<T>(obj: T): T {
   if (Array.isArray(obj)) return obj.map(omitTypename) as unknown as T;

--- a/client/src/components/pages/developer/CalculatorCanvas/fragmentParser.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/fragmentParser.ts
@@ -1,0 +1,83 @@
+import { RateBuildupTemplateFullSnippetFragment } from "../../../../generated/graphql";
+import {
+  CanvasParameterDef,
+  CanvasTableDef,
+  CanvasFormulaStep,
+  CanvasBreakdownDef,
+  OutputDef,
+  SpecialNodePositions,
+} from "../../../../components/TenderPricing/calculators/types";
+import type {
+  CanvasDocument,
+  GroupDef,
+  ControllerDef,
+} from "./canvasTypes";
+
+/**
+ * Convert a GraphQL RateBuildupTemplate fragment into a CanvasDocument.
+ *
+ * Handles:
+ * - specialPositions arriving as JSON string OR typed object (fallback to defaults on parse error)
+ * - groupDefs / controllerDefs arriving as typed sub-docs (post-migration) OR legacy JSON strings
+ * - Deduplication of canvas defs by id, and memberIds within groups (protects against historic
+ *   save bugs that duplicated entries)
+ */
+export function fragmentToDoc(f: RateBuildupTemplateFullSnippetFragment): CanvasDocument {
+  const specialPositions: SpecialNodePositions = {
+    quantity: { x: 100, y: 200 },
+    unitPrice: { x: 700, y: 200 },
+  };
+  if (f.specialPositions) {
+    try {
+      const sp = typeof f.specialPositions === "string"
+        ? JSON.parse(f.specialPositions)
+        : f.specialPositions;
+      if (sp?.quantity) specialPositions.quantity = sp.quantity;
+      if (sp?.unitPrice) specialPositions.unitPrice = sp.unitPrice;
+    } catch { /* ignore */ }
+  }
+
+  let groupDefs: GroupDef[] = [];
+  if (Array.isArray(f.groupDefs)) {
+    groupDefs = f.groupDefs as GroupDef[];
+  } else if (typeof f.groupDefs === "string") {
+    try { groupDefs = JSON.parse(f.groupDefs); } catch { /* ignore */ }
+  }
+  groupDefs = groupDefs.map((g) => ({ ...g, memberIds: [...new Set(g.memberIds)] }));
+
+  let controllerDefs: ControllerDef[] = [];
+  if (Array.isArray(f.controllerDefs)) {
+    controllerDefs = f.controllerDefs as ControllerDef[];
+  } else if (typeof f.controllerDefs === "string") {
+    try { controllerDefs = JSON.parse(f.controllerDefs); } catch { /* ignore */ }
+  }
+
+  const dedup = <T extends { id: string }>(arr: T[]): T[] => {
+    const seen = new Set<string>();
+    return arr.filter((item) => {
+      if (seen.has(item.id)) return false;
+      seen.add(item.id);
+      return true;
+    });
+  };
+
+  return {
+    id: f._id,
+    label: f.label,
+    defaultUnit: f.defaultUnit ?? "unit",
+    parameterDefs: dedup((f.parameterDefs ?? []) as CanvasParameterDef[]),
+    tableDefs: dedup((f.tableDefs ?? []) as CanvasTableDef[]),
+    formulaSteps: dedup((f.formulaSteps ?? []) as CanvasFormulaStep[]),
+    breakdownDefs: dedup((f.breakdownDefs ?? []) as CanvasBreakdownDef[]),
+    outputDefs: dedup(((f.outputDefs ?? []) as OutputDef[])),
+    specialPositions,
+    groupDefs,
+    controllerDefs,
+    unitVariants: (f.unitVariants ?? []).map(({ unit, activatesGroupId, conversionFormula }) => ({
+      unit,
+      activatesGroupId,
+      conversionFormula: conversionFormula ?? undefined,
+    })),
+    updatedAt: f.updatedAt ?? undefined,
+  };
+}

--- a/client/src/components/pages/developer/CalculatorCanvas/snapshotEvaluator.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/snapshotEvaluator.ts
@@ -268,12 +268,31 @@ export function evaluateSnapshot(
     if (converted !== null && converted > 0) quantity = converted;
   }
 
+  // Build controller numeric context from the template's controllerDefs, not
+  // from snapshot.controllers alone. Any defined percentage/toggle controller
+  // must be present in the formula evaluation ctx even when the snapshot has
+  // no explicit value, otherwise formula steps that reference the controller
+  // id by name throw "undefined variable" inside expr-eval and safeEval
+  // collapses the whole formula to 0. RateBuildupInputs' live preview uses
+  // the same controllerDefs-based approach; the two must agree.
   const controllerNumeric: Record<string, number> = {};
-  for (const [k, v] of Object.entries(snapshot.controllers ?? {})) {
-    if (typeof v === "number") controllerNumeric[k] = v;
-    else if (typeof v === "boolean") controllerNumeric[k] = v ? 1 : 0;
+  const snapControllers = snapshot.controllers ?? {};
+  for (const c of doc.controllerDefs ?? []) {
+    const v = snapControllers[c.id];
+    if (typeof v === "number") {
+      controllerNumeric[c.id] = v;
+    } else if (typeof v === "boolean") {
+      controllerNumeric[c.id] = v ? 1 : 0;
+    } else if (c.type === "percentage") {
+      controllerNumeric[c.id] =
+        typeof c.defaultValue === "number" ? c.defaultValue : 0;
+    } else if (c.type === "toggle") {
+      controllerNumeric[c.id] = c.defaultValue ? 1 : 0;
+    }
+    // selector controllers aren't numeric — skip (their activation is
+    // evaluated separately via isGroupActive).
   }
-  const inactiveNodeIds = computeInactiveNodeIds(doc, snapshot.controllers ?? {}, unit);
+  const inactiveNodeIds = computeInactiveNodeIds(doc, snapControllers, unit);
   const result = evaluateTemplate(
     doc,
     { params: snapshot.params, tables: snapshot.tables },

--- a/client/src/components/pages/developer/CalculatorCanvas/snapshotEvaluator.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/snapshotEvaluator.ts
@@ -2,6 +2,7 @@ import { RateBuildupOutputKind } from "../../../../generated/graphql";
 import {
   RateEntry,
   EvaluatedOutput,
+  CalculatorResult,
 } from "../../../../components/TenderPricing/calculators/types";
 import {
   evaluateTemplate,
@@ -240,6 +241,92 @@ export function canvasDocToSnapshot(
 }
 
 /**
+ * Core evaluator shared by both the save path (evaluateSnapshot) and the live
+ * preview path (RateBuildupInputs). Takes the decomposed pieces of a snapshot
+ * rather than a RateBuildupSnapshot so that RateBuildupInputs — which holds
+ * the pieces in local React state and has no snapshot to pass — can call it
+ * without round-tripping through a snapshot object.
+ *
+ * Centralising this logic is deliberate: the two code paths used to duplicate
+ * the quantity normalization, controller-context construction, and inactive
+ * node computation. A prior divergence (empty `snapshot.controllers` combined
+ * with a formula that referenced a controller id) caused the saved unit price
+ * to silently differ from the displayed one — exactly the class of bug that
+ * a single shared helper makes impossible by construction.
+ *
+ * Returns the CalculatorResult plus the intermediate values the preview path
+ * needs for its debug panel and output rendering.
+ */
+export function evaluateCanvasDoc(
+  doc: CanvasDocument,
+  params: Record<string, number>,
+  tables: Record<string, RateEntry[]>,
+  controllers: Record<string, number | boolean | string[]>,
+  rawQuantity: number,
+  unit?: string
+): {
+  result: CalculatorResult;
+  normalizedQuantity: number;
+  controllerNumeric: Record<string, number>;
+  inactiveNodeIds: Set<string>;
+} {
+  // 1. Normalize quantity via unit variant conversion formula (if any).
+  //    Uses params[p.id] falling back to each param's defaultValue, matching
+  //    the formula evaluation context defaults.
+  let normalizedQuantity = rawQuantity;
+  const variant = unit
+    ? (doc.unitVariants ?? []).find((v) => v.unit === unit)
+    : undefined;
+  if (variant?.conversionFormula) {
+    const ctx: Record<string, number> = { quantity: rawQuantity };
+    for (const p of doc.parameterDefs) {
+      ctx[p.id] = params[p.id] ?? p.defaultValue;
+    }
+    const converted = evaluateExpression(variant.conversionFormula, ctx);
+    if (converted !== null && converted > 0) normalizedQuantity = converted;
+  }
+
+  // 2. Build controller numeric context from the template's controllerDefs.
+  //    Every defined percentage/toggle controller gets a numeric entry, even
+  //    when the caller's `controllers` map has no value for it — otherwise
+  //    formula steps that reference the controller id by name crash inside
+  //    expr-eval and safeEval collapses the whole step to 0. Unset entries
+  //    fall back to the def's own defaultValue (not a hardcoded 0), matching
+  //    how isGroupActive treats missing controllers.
+  const controllerNumeric: Record<string, number> = {};
+  for (const c of doc.controllerDefs ?? []) {
+    const v = controllers[c.id];
+    if (typeof v === "number") {
+      controllerNumeric[c.id] = v;
+    } else if (typeof v === "boolean") {
+      controllerNumeric[c.id] = v ? 1 : 0;
+    } else if (c.type === "percentage") {
+      controllerNumeric[c.id] =
+        typeof c.defaultValue === "number" ? c.defaultValue : 0;
+    } else if (c.type === "toggle") {
+      controllerNumeric[c.id] = c.defaultValue ? 1 : 0;
+    }
+    // selector controllers aren't numeric — skip. Their activation is
+    // evaluated separately via isGroupActive.
+  }
+
+  // 3. Which nodes are inactive (inside groups whose activation evaluates
+  //    to false, or on the wrong branch of a unit variant).
+  const inactiveNodeIds = computeInactiveNodeIds(doc, controllers, unit);
+
+  // 4. Evaluate the full template.
+  const result = evaluateTemplate(
+    doc,
+    { params, tables },
+    normalizedQuantity,
+    controllerNumeric,
+    inactiveNodeIds
+  );
+
+  return { result, normalizedQuantity, controllerNumeric, inactiveNodeIds };
+}
+
+/**
  * Evaluate a snapshot against a quantity, returning both the unit price and the
  * resolved Output node values. All save paths should call this and persist
  * BOTH values atomically — outputs are derived from the same ctx as unitPrice,
@@ -257,48 +344,13 @@ export function evaluateSnapshot(
   unit?: string
 ): { unitPrice: number; outputs: PricingRowOutput[] } {
   const doc = snapshotToCanvasDoc(snapshot);
-
-  // Resolve active unit variant and normalize quantity via conversion formula
-  const variant = unit ? (doc.unitVariants ?? []).find((v) => v.unit === unit) : undefined;
-  let quantity = rawQuantity;
-  if (variant?.conversionFormula) {
-    const ctx: Record<string, number> = { quantity: rawQuantity };
-    for (const p of doc.parameterDefs) ctx[p.id] = snapshot.params[p.id] ?? p.defaultValue;
-    const converted = evaluateExpression(variant.conversionFormula, ctx);
-    if (converted !== null && converted > 0) quantity = converted;
-  }
-
-  // Build controller numeric context from the template's controllerDefs, not
-  // from snapshot.controllers alone. Any defined percentage/toggle controller
-  // must be present in the formula evaluation ctx even when the snapshot has
-  // no explicit value, otherwise formula steps that reference the controller
-  // id by name throw "undefined variable" inside expr-eval and safeEval
-  // collapses the whole formula to 0. RateBuildupInputs' live preview uses
-  // the same controllerDefs-based approach; the two must agree.
-  const controllerNumeric: Record<string, number> = {};
-  const snapControllers = snapshot.controllers ?? {};
-  for (const c of doc.controllerDefs ?? []) {
-    const v = snapControllers[c.id];
-    if (typeof v === "number") {
-      controllerNumeric[c.id] = v;
-    } else if (typeof v === "boolean") {
-      controllerNumeric[c.id] = v ? 1 : 0;
-    } else if (c.type === "percentage") {
-      controllerNumeric[c.id] =
-        typeof c.defaultValue === "number" ? c.defaultValue : 0;
-    } else if (c.type === "toggle") {
-      controllerNumeric[c.id] = c.defaultValue ? 1 : 0;
-    }
-    // selector controllers aren't numeric — skip (their activation is
-    // evaluated separately via isGroupActive).
-  }
-  const inactiveNodeIds = computeInactiveNodeIds(doc, snapControllers, unit);
-  const result = evaluateTemplate(
+  const { result } = evaluateCanvasDoc(
     doc,
-    { params: snapshot.params, tables: snapshot.tables },
-    quantity,
-    controllerNumeric,
-    inactiveNodeIds
+    snapshot.params,
+    snapshot.tables,
+    snapshot.controllers ?? {},
+    rawQuantity,
+    unit
   );
 
   // Resolve each evaluated output: the estimator's snapshot selection overrides

--- a/client/src/pages/_document.tsx
+++ b/client/src/pages/_document.tsx
@@ -25,6 +25,12 @@ export default class MyDocument extends Document {
           />
           <link rel="apple-touch-icon" href="/icons/apple-icon.png"></link>
           <meta name="theme-color" content="#ef2e25" />
+          <meta name="apple-mobile-web-app-capable" content="yes" />
+          <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+          <meta
+            name="apple-mobile-web-app-title"
+            content={`Bow Mark${process.env.NEXT_PUBLIC_APP_NAME ? ` ${process.env.NEXT_PUBLIC_APP_NAME}` : ""}`}
+          />
 
           <script
             async

--- a/client/tests/e2e/tender-pricing.spec.ts
+++ b/client/tests/e2e/tender-pricing.spec.ts
@@ -18,36 +18,140 @@
  *     m2 + waste on                   : 14.40 + 50.00 + 1.50  = $65.90
  *     m2 + depth 0.08 + waste off     : 23.04 + 50.00 + 0     = $73.04
  *     m3 + waste off (conv qty=2000)  : 14.40 +  2.50 + 0     = $16.90
+ *
+ * State reset strategy: we snapshot the seeded row's full rateBuildupSnapshot
+ * + rateBuildupOutputs once in beforeAll, then replay them via a direct
+ * GraphQL mutation before each test. This is ~1s per test vs ~25s for a full
+ * reseed, and guarantees pristine snapshot state even if a prior test mutated
+ * params, controllers, or output selections inside the JSON blob.
  */
-import { expect, test, type Page, type Locator } from "@playwright/test";
+import { expect, test, type APIRequestContext, type Page, type Locator } from "@playwright/test";
 
 const TENDER_ID = "629a49205f76f65244785d01";
 const SHEET_ID = "629a49205f76f65244785d02";
 const ROW_ID = "629a49205f76f65244785d03";
+const GRAPHQL_URL = "http://localhost:4001/graphql";
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// ── State reset — login + seeded row cache ───────────────────────────────────
+
+let authToken: string;
+let seedSnapshotJson: string;
+let seedOutputs: any[];
+let seedUnit: string;
+let seedQuantity: number;
+let seedUnitPrice: number;
+
+async function gqlLogin(request: APIRequestContext): Promise<string> {
+  const res = await request.post(GRAPHQL_URL, {
+    data: {
+      query: `
+        mutation Login($data: LoginData!) {
+          login(data: $data)
+        }
+      `,
+      variables: {
+        data: { email: "admin@bowmark.ca", password: "password", rememberMe: true },
+      },
+    },
+  });
+  const body = await res.json();
+  if (!body.data?.login) throw new Error(`Login failed: ${JSON.stringify(body)}`);
+  return body.data.login as string;
+}
+
+/**
+ * Query the seeded row and stash its snapshot + outputs for later reset.
+ * Runs once before all tests, after globalSetup has finished seeding.
+ */
+async function captureSeedRowState(request: APIRequestContext) {
+  const res = await request.post(GRAPHQL_URL, {
+    headers: { Authorization: authToken },
+    data: {
+      query: `
+        query ($tenderId: ID!) {
+          tenderPricingSheet(tenderId: $tenderId) {
+            _id
+            rows {
+              _id
+              quantity
+              unit
+              unitPrice
+              rateBuildupSnapshot
+              rateBuildupOutputs {
+                kind
+                materialId
+                crewKindId
+                unit
+                perUnitValue
+                totalValue
+              }
+            }
+          }
+        }
+      `,
+      variables: { tenderId: TENDER_ID },
+    },
+  });
+  const body = await res.json();
+  if (body.errors) throw new Error(`Seed capture failed: ${JSON.stringify(body.errors)}`);
+  const row = body.data.tenderPricingSheet.rows.find((r: any) => r._id === ROW_ID);
+  if (!row) throw new Error(`Seeded row ${ROW_ID} not found`);
+  seedSnapshotJson = row.rateBuildupSnapshot;
+  seedOutputs = (row.rateBuildupOutputs ?? []).map((o: any) => {
+    // Strip Apollo's __typename before sending back as mutation input
+    const { __typename, ...rest } = o;
+    return rest;
+  });
+  seedUnit = row.unit;
+  seedQuantity = row.quantity;
+  seedUnitPrice = row.unitPrice;
+}
+
+/**
+ * Replay the seeded row state — scalar fields, snapshot blob, and outputs —
+ * via the same mutation the client uses. Runs in beforeEach to guarantee
+ * each test starts from a pristine state.
+ */
+async function resetRowState(request: APIRequestContext) {
+  const res = await request.post(GRAPHQL_URL, {
+    headers: { Authorization: authToken },
+    data: {
+      query: `
+        mutation Reset($sheetId: ID!, $rowId: ID!, $data: TenderPricingRowUpdateData!) {
+          tenderPricingRowUpdate(sheetId: $sheetId, rowId: $rowId, data: $data) { _id }
+        }
+      `,
+      variables: {
+        sheetId: SHEET_ID,
+        rowId: ROW_ID,
+        data: {
+          quantity: seedQuantity,
+          unit: seedUnit,
+          unitPrice: seedUnitPrice,
+          rateBuildupSnapshot: seedSnapshotJson,
+          rateBuildupOutputs: seedOutputs,
+        },
+      },
+    },
+  });
+  const body = await res.json();
+  if (body.errors) throw new Error(`Reset failed: ${JSON.stringify(body.errors)}`);
+}
+
+// ── UI helpers ───────────────────────────────────────────────────────────────
 
 async function goTender(page: Page) {
   await page.goto(`/tender/${TENDER_ID}`);
-  // Wait for the pricing row (description "E2E Paving Row") to render. This
-  // guards against navigating before the Apollo query resolves.
   await expect(
     page.getByText("E2E Paving Row", { exact: true }).first()
   ).toBeVisible({ timeout: 15_000 });
 }
 
 async function openDetail(page: Page) {
-  // Clicking the row description in the pricing table opens LineItemDetail.
   await page.getByText("E2E Paving Row", { exact: true }).first().click();
-  // The buildup unit price testid only mounts when a row is selected.
   await expect(page.getByTestId("buildup-unit-price")).toBeVisible({ timeout: 10_000 });
 }
 
-/**
- * Expand the Rate Buildup section if it's currently collapsed. The section
- * mounts even when collapsed (so the evaluator keeps firing), but the input
- * fields are display:none until expanded.
- */
 async function expandBuildup(page: Page) {
   const expandLabel = page.getByText(/^expand$/i).first();
   if (await expandLabel.isVisible().catch(() => false)) {
@@ -55,7 +159,6 @@ async function expandBuildup(page: Page) {
   }
 }
 
-/** Parse "$NN.NN" into a number. */
 function parsePrice(text: string): number {
   return parseFloat(text.replace(/[^0-9.]/g, ""));
 }
@@ -70,11 +173,6 @@ async function readRowUnitPrice(page: Page): Promise<number> {
   return parsePrice(txt);
 }
 
-/**
- * Locate a parameter input by its visible label (e.g. "Depth (m)"). The
- * ParamRow renders <Text>{label}</Text> then <Input type="number"> inside
- * the same container, so we anchor on the label and walk to the next input.
- */
 function paramInput(page: Page, labelSubstring: string): Locator {
   return page
     .getByText(labelSubstring, { exact: false })
@@ -83,55 +181,46 @@ function paramInput(page: Page, labelSubstring: string): Locator {
 }
 
 /**
- * Reset the row back to baseline via a direct GraphQL mutation. Called from
- * afterEach so each test starts from a known state without re-seeding.
+ * Returns a promise that resolves on the next tenderPricingRowUpdate response
+ * from the GraphQL endpoint. MUST be started BEFORE the action that triggers
+ * the save — otherwise a fast mutation can complete before the listener
+ * attaches and the wait will time out.
+ *
+ * Usage:
+ *   const waiter = pendingRowSave(page);
+ *   await doSomethingThatTriggersSave();
+ *   await waiter;
  */
-async function resetRow(page: Page) {
-  await page.evaluate(
-    async ({ sheetId, rowId }) => {
-      // Reset both the quantity/unit/unitPrice AND re-send the default snapshot
-      // via the tenderPricingRowUpdate mutation. We don't touch rateBuildupSnapshot
-      // here since the UI will recompute from whatever is stored next time the
-      // detail opens; the unitPrice + unit + quantity fields are sufficient to
-      // restore the visual baseline.
-      const mutation = `
-        mutation ResetRow($sheetId: ID!, $rowId: ID!, $data: TenderPricingRowUpdateData!) {
-          tenderPricingRowUpdate(sheetId: $sheetId, rowId: $rowId, data: $data) { _id }
-        }
-      `;
-      await fetch("/graphql", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({
-          query: mutation,
-          variables: {
-            sheetId,
-            rowId,
-            data: { quantity: 100, unit: "m2", unitPrice: 64.4 },
-          },
-        }),
-      });
-    },
-    { sheetId: SHEET_ID, rowId: ROW_ID }
+function pendingRowSave(page: Page) {
+  return page.waitForResponse(
+    (res) =>
+      res.url().includes("/graphql") &&
+      res.request().method() === "POST" &&
+      res.request().postData()?.includes("tenderPricingRowUpdate") === true,
+    { timeout: 8_000 }
   );
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
+test.describe.configure({ mode: "serial" });
+
 test.describe("Tender pricing — golden path wire", () => {
-  test.afterEach(async ({ page }) => {
-    await resetRow(page);
+  test.beforeAll(async ({ request }) => {
+    authToken = await gqlLogin(request);
+    await captureSeedRowState(request);
+  });
+
+  test.beforeEach(async ({ request }) => {
+    await resetRowState(request);
   });
 
   test("initial load shows seeded unit price $64.40 in row + detail", async ({ page }) => {
     await goTender(page);
 
-    // Full-width table is rendered when no row is selected.
     const rowPrice = await readRowUnitPrice(page);
     expect(rowPrice).toBeCloseTo(64.4, 2);
 
-    // Open detail → price mirrors in the buildup summary.
     await openDetail(page);
     const detailPrice = await readDetailUnitPrice(page);
     expect(detailPrice).toBeCloseTo(64.4, 2);
@@ -142,26 +231,114 @@ test.describe("Tender pricing — golden path wire", () => {
     await openDetail(page);
     await expandBuildup(page);
 
-    // Change depth 0.05 → 0.08
     const input = paramInput(page, "Depth");
+    const savePending = pendingRowSave(page);
     await input.fill("0.08");
     await input.blur();
 
-    // Wait for debounced save (500ms client-side + mutation roundtrip)
+    // Wait for the debounced save (500ms) to reach the server, then verify
+    // the DOM reflects the new value.
+    await savePending;
     await expect(async () => {
-      const price = await readDetailUnitPrice(page);
-      // 0.08 * 2.4 * 120 + 5000/100 = 23.04 + 50 = 73.04
-      expect(price).toBeCloseTo(73.04, 1);
-    }).toPass({ timeout: 6_000 });
+      expect(await readDetailUnitPrice(page)).toBeCloseTo(73.04, 1);
+    }).toPass({ timeout: 4_000 });
 
-    // Reload — the detail pane persists its selected row across reloads via
-    // URL/state, so the buildup unit price testid remounts and must show the
-    // saved value after hydrating from the DB.
     await page.reload();
     await expect(page.getByTestId("buildup-unit-price")).toBeVisible({ timeout: 15_000 });
     await expect(async () => {
-      const reloaded = await readDetailUnitPrice(page);
-      expect(reloaded).toBeCloseTo(73.04, 1);
+      expect(await readDetailUnitPrice(page)).toBeCloseTo(73.04, 1);
     }).toPass({ timeout: 5_000 });
+  });
+
+  test("switching unit variant m2 → m3 recomputes via conversion formula", async ({ page }) => {
+    await goTender(page);
+    await openDetail(page);
+
+    // The Unit <select> lives in the Quantity card inside LineItemDetail.
+    // Changing unit fires onUpdate immediately (no debounce), so we set up
+    // the listener first.
+    const unitSelect = page.getByRole("combobox").filter({ hasText: "m²" }).first();
+    const savePending = pendingRowSave(page);
+    await unitSelect.selectOption("m3");
+    await savePending;
+
+    // raw qty 100 → converted 100/0.05 = 2000
+    // mat_per_unit = 0.05*2.4*120 = 14.40
+    // lab_per_unit = 5000/2000    =  2.50
+    // total = 16.90
+    await expect(async () => {
+      expect(await readDetailUnitPrice(page)).toBeCloseTo(16.9, 1);
+    }).toPass({ timeout: 4_000 });
+
+    await page.reload();
+    await expect(page.getByTestId("buildup-unit-price")).toBeVisible({ timeout: 15_000 });
+    await expect(async () => {
+      expect(await readDetailUnitPrice(page)).toBeCloseTo(16.9, 1);
+    }).toPass({ timeout: 5_000 });
+  });
+
+  test("toggling waste group adds fixed per-unit cost", async ({ page }) => {
+    await goTender(page);
+    await openDetail(page);
+    await expandBuildup(page);
+
+    await expect(async () => {
+      expect(await readDetailUnitPrice(page)).toBeCloseTo(64.4, 2);
+    }).toPass({ timeout: 3_000 });
+
+    // The toggle switch lives in the Waste group card header. It has a
+    // stable testid so we don't depend on the click coordinates inside the
+    // small Chakra pill.
+    const savePending = pendingRowSave(page);
+    await page.getByTestId("group-toggle-g_waste").click();
+    await savePending;
+
+    // 64.40 + 1.50 = 65.90
+    await expect(async () => {
+      expect(await readDetailUnitPrice(page)).toBeCloseTo(65.9, 2);
+    }).toPass({ timeout: 4_000 });
+
+    await page.reload();
+    await expect(page.getByTestId("buildup-unit-price")).toBeVisible({ timeout: 15_000 });
+    await expect(async () => {
+      expect(await readDetailUnitPrice(page)).toBeCloseTo(65.9, 2);
+    }).toPass({ timeout: 5_000 });
+  });
+
+  test("changing output material selection persists through reload", async ({ page }) => {
+    await goTender(page);
+    await openDetail(page);
+    await expandBuildup(page);
+
+    // Material picker lives in the Demand section. Anchor on the "Asphalt"
+    // OutputDef label then the nearest combobox below it.
+    const picker = page
+      .getByText("Asphalt", { exact: true })
+      .first()
+      .locator("xpath=following::select[1]");
+
+    const initialValue = await picker.inputValue();
+    await expect(
+      picker.locator(`option[value="${initialValue}"]`)
+    ).toHaveText("Material 1");
+
+    const savePending = pendingRowSave(page);
+    await picker.selectOption({ label: "Second Material" });
+    const newValue = await picker.inputValue();
+    expect(newValue).not.toBe(initialValue);
+
+    // Wait for debounced save to reach the server.
+    await savePending;
+
+    // Reload — picker should rehydrate with the saved selection
+    await page.reload();
+    await expect(page.getByTestId("buildup-unit-price")).toBeVisible({ timeout: 15_000 });
+    await expandBuildup(page);
+
+    const pickerAfter = page
+      .getByText("Asphalt", { exact: true })
+      .first()
+      .locator("xpath=following::select[1]");
+    await expect(pickerAfter).toHaveValue(newValue);
   });
 });

--- a/client/tests/e2e/tender-pricing.spec.ts
+++ b/client/tests/e2e/tender-pricing.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * E2E tests for the tender pricing "golden path" wire: UI → Apollo → server → DB → reload.
+ *
+ * These specs are NOT re-validating the evaluator math (that's exhaustively
+ * unit-tested). They exercise the plumbing between the already-proven pieces:
+ * RateBuildupInputs event handlers → snapshot state → evaluateSnapshot →
+ * debounced save mutation → DB persist → reload render.
+ *
+ * Seeded fixture (see server/src/testing/documents/):
+ *   Tender:     _ids.tenders.e2e_pricing._id        (629a49205f76f65244785d01)
+ *   Sheet:      _ids.tenders.e2e_pricing.sheetId    (629a49205f76f65244785d02)
+ *   Row:        _ids.tenders.e2e_pricing.rowId      (629a49205f76f65244785d03)
+ *   Template:   "E2E Paving Test"
+ *   Initial unitPrice (qty 100, m2, waste off, defaults): $64.40
+ *
+ *   Expected values under defaults (qty 100):
+ *     m2 + waste off                  : 14.40 + 50.00 + 0     = $64.40
+ *     m2 + waste on                   : 14.40 + 50.00 + 1.50  = $65.90
+ *     m2 + depth 0.08 + waste off     : 23.04 + 50.00 + 0     = $73.04
+ *     m3 + waste off (conv qty=2000)  : 14.40 +  2.50 + 0     = $16.90
+ */
+import { expect, test, type Page, type Locator } from "@playwright/test";
+
+const TENDER_ID = "629a49205f76f65244785d01";
+const SHEET_ID = "629a49205f76f65244785d02";
+const ROW_ID = "629a49205f76f65244785d03";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function goTender(page: Page) {
+  await page.goto(`/tender/${TENDER_ID}`);
+  // Wait for the pricing row (description "E2E Paving Row") to render. This
+  // guards against navigating before the Apollo query resolves.
+  await expect(
+    page.getByText("E2E Paving Row", { exact: true }).first()
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+async function openDetail(page: Page) {
+  // Clicking the row description in the pricing table opens LineItemDetail.
+  await page.getByText("E2E Paving Row", { exact: true }).first().click();
+  // The buildup unit price testid only mounts when a row is selected.
+  await expect(page.getByTestId("buildup-unit-price")).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Expand the Rate Buildup section if it's currently collapsed. The section
+ * mounts even when collapsed (so the evaluator keeps firing), but the input
+ * fields are display:none until expanded.
+ */
+async function expandBuildup(page: Page) {
+  const expandLabel = page.getByText(/^expand$/i).first();
+  if (await expandLabel.isVisible().catch(() => false)) {
+    await expandLabel.click();
+  }
+}
+
+/** Parse "$NN.NN" into a number. */
+function parsePrice(text: string): number {
+  return parseFloat(text.replace(/[^0-9.]/g, ""));
+}
+
+async function readDetailUnitPrice(page: Page): Promise<number> {
+  const txt = (await page.getByTestId("buildup-unit-price").textContent()) ?? "";
+  return parsePrice(txt);
+}
+
+async function readRowUnitPrice(page: Page): Promise<number> {
+  const txt = (await page.getByTestId("row-cost-up").first().textContent()) ?? "";
+  return parsePrice(txt);
+}
+
+/**
+ * Locate a parameter input by its visible label (e.g. "Depth (m)"). The
+ * ParamRow renders <Text>{label}</Text> then <Input type="number"> inside
+ * the same container, so we anchor on the label and walk to the next input.
+ */
+function paramInput(page: Page, labelSubstring: string): Locator {
+  return page
+    .getByText(labelSubstring, { exact: false })
+    .first()
+    .locator("xpath=following::input[@type='number'][1]");
+}
+
+/**
+ * Reset the row back to baseline via a direct GraphQL mutation. Called from
+ * afterEach so each test starts from a known state without re-seeding.
+ */
+async function resetRow(page: Page) {
+  await page.evaluate(
+    async ({ sheetId, rowId }) => {
+      // Reset both the quantity/unit/unitPrice AND re-send the default snapshot
+      // via the tenderPricingRowUpdate mutation. We don't touch rateBuildupSnapshot
+      // here since the UI will recompute from whatever is stored next time the
+      // detail opens; the unitPrice + unit + quantity fields are sufficient to
+      // restore the visual baseline.
+      const mutation = `
+        mutation ResetRow($sheetId: ID!, $rowId: ID!, $data: TenderPricingRowUpdateData!) {
+          tenderPricingRowUpdate(sheetId: $sheetId, rowId: $rowId, data: $data) { _id }
+        }
+      `;
+      await fetch("/graphql", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          query: mutation,
+          variables: {
+            sheetId,
+            rowId,
+            data: { quantity: 100, unit: "m2", unitPrice: 64.4 },
+          },
+        }),
+      });
+    },
+    { sheetId: SHEET_ID, rowId: ROW_ID }
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe("Tender pricing — golden path wire", () => {
+  test.afterEach(async ({ page }) => {
+    await resetRow(page);
+  });
+
+  test("initial load shows seeded unit price $64.40 in row + detail", async ({ page }) => {
+    await goTender(page);
+
+    // Full-width table is rendered when no row is selected.
+    const rowPrice = await readRowUnitPrice(page);
+    expect(rowPrice).toBeCloseTo(64.4, 2);
+
+    // Open detail → price mirrors in the buildup summary.
+    await openDetail(page);
+    const detailPrice = await readDetailUnitPrice(page);
+    expect(detailPrice).toBeCloseTo(64.4, 2);
+  });
+
+  test("changing depth param recomputes and persists across reload", async ({ page }) => {
+    await goTender(page);
+    await openDetail(page);
+    await expandBuildup(page);
+
+    // Change depth 0.05 → 0.08
+    const input = paramInput(page, "Depth");
+    await input.fill("0.08");
+    await input.blur();
+
+    // Wait for debounced save (500ms client-side + mutation roundtrip)
+    await expect(async () => {
+      const price = await readDetailUnitPrice(page);
+      // 0.08 * 2.4 * 120 + 5000/100 = 23.04 + 50 = 73.04
+      expect(price).toBeCloseTo(73.04, 1);
+    }).toPass({ timeout: 6_000 });
+
+    // Reload — the detail pane persists its selected row across reloads via
+    // URL/state, so the buildup unit price testid remounts and must show the
+    // saved value after hydrating from the DB.
+    await page.reload();
+    await expect(page.getByTestId("buildup-unit-price")).toBeVisible({ timeout: 15_000 });
+    await expect(async () => {
+      const reloaded = await readDetailUnitPrice(page);
+      expect(reloaded).toBeCloseTo(73.04, 1);
+    }).toPass({ timeout: 5_000 });
+  });
+});

--- a/server/src/consumer/handlers/enrichedFileSummaryHandler.ts
+++ b/server/src/consumer/handlers/enrichedFileSummaryHandler.ts
@@ -8,6 +8,13 @@ import { scheduleTenderSummary } from "../../lib/generateTenderSummary";
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
+// Matches PROCESSING_STUCK_MS in consumer/index.ts. If a message arrives
+// while another handler is already processing the file, we bail as long as
+// that handler is inside its processing window. After the window elapses,
+// the watchdog treats the file as orphaned and any redelivered message is
+// free to take ownership.
+const HANDLER_OWNERSHIP_WINDOW_MS = 90 * 60_000;
+
 const SUMMARY_PROMPT = `You are processing a construction document for a paving/concrete company.
 Analyze this document and return a JSON object with exactly these fields:
 {
@@ -25,6 +32,43 @@ export const enrichedFileSummaryHandler = {
   async handle(message: EnrichedFileSummaryMessage): Promise<void> {
     const { enrichedFileId, fileId, attempt = 0 } = message;
     console.log(`[EnrichedFileSummary] Processing file ${fileId} (enrichedFile ${enrichedFileId}, attempt ${attempt})`);
+
+    // Idempotency guard — duplicate messages (from watchdog republish, broker
+    // redelivery, rate-limit retry, etc.) must not clobber a file that has
+    // already been processed or is actively being processed by another handler.
+    // Without this, a duplicate for a "ready" file would flip it back to
+    // "processing" and burn Claude tokens re-summarizing.
+    const current = await EnrichedFile.findById(enrichedFileId).lean();
+    if (!current) {
+      console.warn(`[EnrichedFileSummary] File ${enrichedFileId} not found — skipping`);
+      return;
+    }
+    if (current.summaryStatus === "ready") {
+      console.log(`[EnrichedFileSummary] File ${enrichedFileId} already ready — skipping duplicate`);
+      return;
+    }
+    if (current.summaryStatus === "failed") {
+      // Explicit retries (tenderRetrySummary, rescan script) reset status to
+      // "pending" before republishing, so a "failed" status at entry means
+      // this is a stray redelivery of an already-failed attempt. Skip.
+      console.log(`[EnrichedFileSummary] File ${enrichedFileId} is failed — skipping stray delivery`);
+      return;
+    }
+    if (current.summaryStatus === "processing") {
+      const startedAt = current.processingStartedAt?.getTime() ?? 0;
+      const ageMs = Date.now() - startedAt;
+      if (ageMs < HANDLER_OWNERSHIP_WINDOW_MS) {
+        console.log(
+          `[EnrichedFileSummary] File ${enrichedFileId} already owned by another handler (${Math.round(ageMs / 1000)}s ago) — skipping duplicate`
+        );
+        return;
+      }
+      // Ownership window elapsed — the previous handler is presumed dead.
+      // Fall through and take over.
+      console.warn(
+        `[EnrichedFileSummary] File ${enrichedFileId} was in processing for ${Math.round(ageMs / 60_000)}min — taking ownership`
+      );
+    }
 
     await EnrichedFile.findByIdAndUpdate(enrichedFileId, {
       $set: {

--- a/server/src/consumer/index.ts
+++ b/server/src/consumer/index.ts
@@ -66,8 +66,12 @@ const WATCHDOG_INTERVAL_MS = 10 * 60_000; // 10 min
 /** Max time a file can be in "processing" before the watchdog reclaims it. */
 const PROCESSING_STUCK_MS = 90 * 60_000; // 90 min (generous — large PDFs can take 45+ min)
 
-/** Max time a file can be in "pending" before the watchdog republishes it. */
-const PENDING_STUCK_MS = 10 * 60_000; // 10 min
+/** Max time a file can be in "pending" since its last publish before the
+ *  watchdog republishes it. Checked against `queuedAt` (fallback: `createdAt`
+ *  for legacy docs that pre-date the field). Must be comfortably larger than
+ *  the worst-case queue-drain time for a large upload batch (60+ files at
+ *  prefetch=2 with 2–5 min per file ≈ up to 2.5 h). */
+const PENDING_STUCK_MS = 3 * 60 * 60_000; // 3 hr
 
 /** Cooldown before retrying a "failed" file. */
 const FAILED_RETRY_COOLDOWN_MS = 60 * 60_000; // 1 hr
@@ -178,11 +182,18 @@ async function recoverStuckFiles(): Promise<void> {
     .populate("file")
     .lean();
 
-  // Files in "pending" older than the pending cutoff (createdAt, since updatedAt
-  // isn't tracked). Covers: publish-to-queue failure, broker drop.
+  // Files in "pending" whose last publish timestamp is older than the cutoff.
+  // `queuedAt` is stamped by every call to publishEnrichedFileCreated, so a
+  // fresh queuedAt means the file is legitimately waiting in the queue behind
+  // a batch and must not be republished (republishing creates duplicate queue
+  // messages — the root cause of the Ready→Processing loop bug). Legacy docs
+  // without the field fall back to `createdAt`.
   const stuckPending = await EnrichedFile.find({
     summaryStatus: "pending",
-    createdAt: { $lt: pendingCutoff },
+    $or: [
+      { queuedAt: { $exists: true, $lt: pendingCutoff } },
+      { queuedAt: { $exists: false }, createdAt: { $lt: pendingCutoff } },
+    ],
   })
     .populate("file")
     .lean();

--- a/server/src/models/EnrichedFile/schema/index.ts
+++ b/server/src/models/EnrichedFile/schema/index.ts
@@ -69,6 +69,15 @@ export class EnrichedFileSchema {
   @prop({ required: false })
   public processingStartedAt?: Date;
 
+  // Updated on every publish to the summary queue. Used by watchdog to
+  // distinguish files legitimately waiting in the queue (fresh queuedAt)
+  // from files whose queue message was dropped (stale queuedAt). Without
+  // this, pending files waiting behind a batch get repeatedly republished
+  // by the watchdog using createdAt — creating duplicate queue messages.
+  @Field({ nullable: true })
+  @prop({ required: false })
+  public queuedAt?: Date;
+
   // Incremented each time the handler runs (successfully or otherwise).
   // Used by watchdog to cap retry attempts on persistently failing files.
   @Field({ nullable: true })

--- a/server/src/rabbitmq/publisher.ts
+++ b/server/src/rabbitmq/publisher.ts
@@ -9,6 +9,7 @@
  * ensures the consumer always sees the latest state.
  */
 
+import mongoose, { Types } from "mongoose";
 import { getChannel, setupTopology, RABBITMQ_CONFIG, ROUTING_KEYS } from ".";
 import type { ActionType } from "./config";
 
@@ -164,6 +165,29 @@ export const publishEnrichedFileCreated = async (
     timestamp: new Date().toISOString(),
     attempt,
   };
+  // Stamp queuedAt BEFORE publishing so the watchdog can distinguish files
+  // legitimately waiting in the queue from files whose message was dropped.
+  // Uses a raw collection write to avoid importing @models (which would
+  // introduce a circular import via post-save hooks). If the publish below
+  // fails, queuedAt still reflects the last attempt; the watchdog retries
+  // once the pending cutoff elapses.
+  try {
+    const db = mongoose.connection.db;
+    if (db) {
+      await db
+        .collection("enrichedfiles")
+        .updateOne(
+          { _id: new Types.ObjectId(enrichedFileId) },
+          { $set: { queuedAt: new Date() } }
+        );
+    }
+  } catch (stampErr) {
+    console.warn(
+      `[RabbitMQ] Failed to stamp queuedAt on ${enrichedFileId}:`,
+      stampErr
+    );
+    // Non-fatal — fall through to publish.
+  }
   try {
     const channel = await getChannel();
     await setupTopology();

--- a/server/src/scripts/reset-stuck-enriched-files.ts
+++ b/server/src/scripts/reset-stuck-enriched-files.ts
@@ -1,0 +1,151 @@
+/**
+ * Reset stuck EnrichedFiles and re-enqueue them cleanly.
+ *
+ * Use after the Ready→Processing loop bug (fixed in the same commit as this
+ * script) to recover files that were left in limbo when the consumer was
+ * scaled down. Resets `summaryStatus` to "pending" and republishes via
+ * `publishEnrichedFileCreated`, which now also stamps `queuedAt` so the
+ * watchdog won't immediately re-duplicate them.
+ *
+ * Unlike rescan-enriched-files.ts, this script:
+ *   - Targets non-ready files (pending/processing/failed) by default
+ *   - Preserves existing summary/pageIndex data (no $unset)
+ *   - Supports targeting a specific tender by id
+ *
+ * Usage:
+ *   ts-node -r tsconfig-paths/register src/scripts/reset-stuck-enriched-files.ts [flags]
+ *
+ * Flags:
+ *   --dry-run            Log what would be reset without making any changes
+ *   --tender <id>        Only reset files belonging to this tender
+ *   --status <list>      Comma-separated statuses to reset (default: pending,processing,failed)
+ *   --id <id>            Reset a single EnrichedFile by its MongoDB _id
+ *
+ * Before running, purge queue duplicates from the incident:
+ *   kubectl exec -it <rabbitmq-pod> -- rabbitmqctl purge_queue enriched.file_summary
+ */
+
+import "reflect-metadata";
+import * as dotenv from "dotenv";
+import path from "path";
+
+if (!process.env.MONGO_URI) {
+  dotenv.config({ path: path.join(__dirname, "../../.env.development") });
+}
+
+import mongoose from "mongoose";
+import { EnrichedFile, Tender } from "../models";
+import { publishEnrichedFileCreated } from "../rabbitmq/publisher";
+
+const VALID_STATUSES = new Set(["pending", "processing", "failed", "ready"]);
+const DEFAULT_STATUSES = ["pending", "processing", "failed"];
+
+const isDryRun = process.argv.includes("--dry-run");
+const getFlag = (name: string): string | null => {
+  const idx = process.argv.indexOf(name);
+  return idx !== -1 ? process.argv[idx + 1] ?? null : null;
+};
+
+const tenderId = getFlag("--tender");
+const targetId = getFlag("--id");
+const statusArg = getFlag("--status");
+
+const statuses = statusArg
+  ? statusArg.split(",").map((s) => s.trim()).filter(Boolean)
+  : DEFAULT_STATUSES;
+
+for (const s of statuses) {
+  if (!VALID_STATUSES.has(s)) {
+    console.error(`[reset] Invalid status: ${s}. Valid: ${[...VALID_STATUSES].join(", ")}`);
+    process.exit(1);
+  }
+}
+
+async function main() {
+  if (!process.env.MONGO_URI) throw new Error("MONGO_URI required");
+  await mongoose.connect(process.env.MONGO_URI, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+    useFindAndModify: false,
+  });
+  console.log("[reset] Connected to MongoDB");
+
+  let query: Record<string, unknown>;
+  if (targetId) {
+    query = { _id: new mongoose.Types.ObjectId(targetId) };
+  } else if (tenderId) {
+    const tender = await Tender.findById(tenderId).lean();
+    if (!tender) throw new Error(`Tender ${tenderId} not found`);
+    const fileIds = ((tender as any).files as any[]).map((f: any) =>
+      f._id ? f._id.toString() : f.toString()
+    );
+    query = {
+      _id: { $in: fileIds.map((id) => new mongoose.Types.ObjectId(id)) },
+      summaryStatus: { $in: statuses },
+    };
+  } else {
+    query = { summaryStatus: { $in: statuses } };
+  }
+
+  const files = await EnrichedFile.find(query).populate("file").lean();
+  console.log(
+    `[reset] Found ${files.length} file(s) to reset — statuses: [${statuses.join(", ")}]` +
+    `${tenderId ? ` tender: ${tenderId}` : ""}` +
+    `${isDryRun ? " (dry run — no changes will be made)" : ""}`
+  );
+
+  if (files.length === 0) {
+    await mongoose.disconnect();
+    return;
+  }
+
+  const byStatus = files.reduce<Record<string, number>>((acc, f) => {
+    const s = (f as any).summaryStatus as string;
+    acc[s] = (acc[s] ?? 0) + 1;
+    return acc;
+  }, {});
+  console.log(`[reset] Breakdown: ${JSON.stringify(byStatus)}`);
+
+  let count = 0;
+  for (const f of files) {
+    if (!f.file) {
+      console.warn(`[reset] Skipping ${f._id} — no file ref`);
+      continue;
+    }
+    const fileRef = f.file as { _id?: unknown };
+    const fileId = fileRef._id
+      ? (fileRef._id as { toString(): string }).toString()
+      : (f.file as { toString(): string }).toString();
+
+    console.log(`[reset] ${isDryRun ? "[dry-run] " : ""}${f._id} → file ${fileId}`);
+
+    if (!isDryRun) {
+      await EnrichedFile.findByIdAndUpdate(f._id, {
+        $set: { summaryStatus: "pending" },
+        $unset: { processingStartedAt: "", summaryError: "" },
+      });
+      const published = await publishEnrichedFileCreated(
+        f._id.toString(),
+        fileId,
+        0
+      );
+      if (!published) {
+        console.error(`[reset] Failed to publish ${f._id} — broker unreachable?`);
+        continue;
+      }
+      count++;
+      // Small delay to avoid flooding RabbitMQ
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+
+  console.log(
+    `[reset] Done. ${isDryRun ? "Would have reset" : "Reset and re-queued"} ${isDryRun ? files.length : count} file(s).`
+  );
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error("[reset] Fatal:", err);
+  process.exit(1);
+});

--- a/server/src/testing/_ids.ts
+++ b/server/src/testing/_ids.ts
@@ -262,6 +262,26 @@ const _ids = {
       _id: Types.ObjectId("6241fc1132d9ce63e6fbf376"),
     },
   },
+  crewKinds: {
+    e2e_operator: {
+      _id: Types.ObjectId("629a49205f76f65244785b01"),
+    },
+    e2e_labour: {
+      _id: Types.ObjectId("629a49205f76f65244785b02"),
+    },
+  },
+  rateBuildupTemplates: {
+    e2e_paving: {
+      _id: Types.ObjectId("629a49205f76f65244785c01"),
+    },
+  },
+  tenders: {
+    e2e_pricing: {
+      _id: Types.ObjectId("629a49205f76f65244785d01"),
+      sheetId: Types.ObjectId("629a49205f76f65244785d02"),
+      rowId: Types.ObjectId("629a49205f76f65244785d03"),
+    },
+  },
 };
 
 export default _ids;

--- a/server/src/testing/clearDatabase.ts
+++ b/server/src/testing/clearDatabase.ts
@@ -1,6 +1,7 @@
 import {
   Company,
   Crew,
+  CrewKind,
   DailyReport,
   Employee,
   EmployeeWork,
@@ -12,9 +13,12 @@ import {
   Material,
   MaterialShipment,
   Production,
+  RateBuildupTemplate,
   ReportNote,
   Signup,
   System,
+  Tender,
+  TenderPricingSheet,
   User,
   Vehicle,
   VehicleWork,
@@ -24,6 +28,7 @@ const clearDatabase = async () => {
   if (process.env.NODE_ENV !== "production") {
     await Company.deleteMany({});
     await Crew.deleteMany({});
+    await CrewKind.deleteMany({});
     await DailyReport.deleteMany({});
     await Employee.deleteMany({});
     await EmployeeWork.deleteMany({});
@@ -34,9 +39,12 @@ const clearDatabase = async () => {
     await Material.deleteMany({});
     await MaterialShipment.deleteMany({});
     await Production.deleteMany({});
+    await RateBuildupTemplate.deleteMany({});
     await ReportNote.deleteMany({});
     await Signup.deleteMany({});
     await System.deleteMany({});
+    await Tender.deleteMany({});
+    await TenderPricingSheet.deleteMany({});
     await User.deleteMany({});
     await Vehicle.deleteMany({});
     await VehicleWork.deleteMany({});

--- a/server/src/testing/documents/crewKinds.ts
+++ b/server/src/testing/documents/crewKinds.ts
@@ -1,0 +1,29 @@
+import { CrewKind, CrewKindDocument } from "@models";
+import _ids from "@testing/_ids";
+
+export interface SeededCrewKinds {
+  e2e_operator: CrewKindDocument;
+  e2e_labour: CrewKindDocument;
+}
+
+const createCrewKinds = async (): Promise<SeededCrewKinds> => {
+  const e2e_operator = new CrewKind({
+    _id: _ids.crewKinds.e2e_operator._id,
+    name: "E2E Operator",
+    description: "Seeded crew kind used by tender pricing E2E tests.",
+  });
+
+  const e2e_labour = new CrewKind({
+    _id: _ids.crewKinds.e2e_labour._id,
+    name: "E2E Labour",
+    description: "Seeded crew kind used by tender pricing E2E tests.",
+  });
+
+  const crewKinds = { e2e_operator, e2e_labour };
+  for (const doc of Object.values(crewKinds)) {
+    await doc.save();
+  }
+  return crewKinds;
+};
+
+export default createCrewKinds;

--- a/server/src/testing/documents/rateBuildupTemplates.ts
+++ b/server/src/testing/documents/rateBuildupTemplates.ts
@@ -32,6 +32,10 @@ const createRateBuildupTemplates = async (): Promise<SeededRateBuildupTemplates>
       { id: "depth_m", label: "Depth (m)", defaultValue: 0.05, position: pos },
       { id: "price_per_t", label: "$/t", defaultValue: 120, position: pos },
       { id: "labour_lump", label: "Labour Lump $", defaultValue: 5000, position: pos },
+      // Lives inside g_waste so the group has at least one user input and
+      // therefore renders in the RateBuildupInputs panel. Also makes the
+      // waste rate editable so tests can verify the formula picks it up.
+      { id: "waste_rate", label: "Waste $/unit", defaultValue: 1.5, position: pos },
     ],
     tableDefs: [],
     formulaSteps: [
@@ -50,7 +54,7 @@ const createRateBuildupTemplates = async (): Promise<SeededRateBuildupTemplates>
       {
         id: "waste_per_unit",
         label: "Waste per unit",
-        formula: "1.5",
+        formula: "waste_rate",
         position: pos,
       },
       {
@@ -127,7 +131,7 @@ const createRateBuildupTemplates = async (): Promise<SeededRateBuildupTemplates>
       {
         id: "g_waste",
         label: "Waste group",
-        memberIds: ["waste_per_unit"],
+        memberIds: ["waste_rate", "waste_per_unit"],
         activation: { controllerId: "waste_toggle", condition: "=== 1" },
         position: pos,
       },

--- a/server/src/testing/documents/rateBuildupTemplates.ts
+++ b/server/src/testing/documents/rateBuildupTemplates.ts
@@ -1,0 +1,158 @@
+import { RateBuildupTemplate, RateBuildupTemplateDocument } from "@models";
+import _ids from "@testing/_ids";
+
+export interface SeededRateBuildupTemplates {
+  e2e_paving: RateBuildupTemplateDocument;
+}
+
+/**
+ * E2E Paving Test template — designed to exercise every wire path the Playwright
+ * E2E tests need to verify without duplicating the exhaustive math unit tests.
+ *
+ * Coverage (expected unit prices at defaults, qty 100):
+ *
+ *   Variant | Waste   | Material | Labour (amortised) | Waste | unitPrice
+ *   --------|---------|----------|--------------------|-------|-----------
+ *   m2      | off     | 14.40    | 50.00 (5000/100)   | 0     | 64.40
+ *   m2      | on      | 14.40    | 50.00              | 1.50  | 65.90
+ *   m2 (*)  | off     | 23.04    | 50.00              | 0     | 73.04  (depth 0.08)
+ *   m3      | off     | 14.40    |  2.50 (5000/2000)  | 0     | 16.90  (converted qty)
+ *
+ * The m3 unit variant applies conversionFormula `quantity / depth_m`, so the
+ * raw row quantity (100) becomes 2000 in the evaluation context.
+ */
+const createRateBuildupTemplates = async (): Promise<SeededRateBuildupTemplates> => {
+  const pos = { x: 0, y: 0 };
+
+  const e2e_paving = new RateBuildupTemplate({
+    _id: _ids.rateBuildupTemplates.e2e_paving._id,
+    label: "E2E Paving Test",
+    defaultUnit: "m2",
+    parameterDefs: [
+      { id: "depth_m", label: "Depth (m)", defaultValue: 0.05, position: pos },
+      { id: "price_per_t", label: "$/t", defaultValue: 120, position: pos },
+      { id: "labour_lump", label: "Labour Lump $", defaultValue: 5000, position: pos },
+    ],
+    tableDefs: [],
+    formulaSteps: [
+      {
+        id: "mat_per_unit",
+        label: "Material per unit",
+        formula: "depth_m * 2.4 * price_per_t",
+        position: pos,
+      },
+      {
+        id: "lab_per_unit",
+        label: "Labour per unit",
+        formula: "labour_lump / quantity",
+        position: pos,
+      },
+      {
+        id: "waste_per_unit",
+        label: "Waste per unit",
+        formula: "1.5",
+        position: pos,
+      },
+      {
+        id: "mat_tons_total",
+        label: "Material tons (row total)",
+        formula: "quantity * depth_m * 2.4",
+        position: pos,
+      },
+      {
+        id: "crew_hours_total",
+        label: "Crew hours (row total)",
+        formula: "quantity * 0.02",
+        position: pos,
+      },
+    ],
+    breakdownDefs: [
+      {
+        id: "bd_material",
+        label: "Material",
+        items: [{ stepId: "mat_per_unit", label: "Material" }],
+        position: pos,
+      },
+      {
+        id: "bd_labour",
+        label: "Labour",
+        items: [{ stepId: "lab_per_unit", label: "Labour" }],
+        position: pos,
+      },
+      {
+        id: "bd_waste",
+        label: "Waste",
+        items: [{ stepId: "waste_per_unit", label: "Waste" }],
+        position: pos,
+      },
+    ],
+    outputDefs: [
+      {
+        id: "out_asphalt",
+        kind: "Material",
+        sourceStepId: "mat_tons_total",
+        unit: "t",
+        label: "Asphalt",
+        allowedMaterialIds: [
+          _ids.materials.material_1._id,
+          _ids.materials.material_2._id,
+        ],
+        defaultMaterialId: _ids.materials.material_1._id,
+        position: pos,
+      },
+      {
+        id: "out_crew",
+        kind: "CrewHours",
+        sourceStepId: "crew_hours_total",
+        unit: "hr",
+        label: "Operator",
+        allowedCrewKindIds: [
+          _ids.crewKinds.e2e_operator._id,
+          _ids.crewKinds.e2e_labour._id,
+        ],
+        defaultCrewKindId: _ids.crewKinds.e2e_operator._id,
+        position: pos,
+      },
+    ],
+    controllerDefs: [
+      {
+        id: "waste_toggle",
+        label: "Include Waste",
+        type: "toggle",
+        defaultValue: 0,
+        position: pos,
+      },
+    ],
+    groupDefs: [
+      {
+        id: "g_waste",
+        label: "Waste group",
+        memberIds: ["waste_per_unit"],
+        activation: { controllerId: "waste_toggle", condition: "=== 1" },
+        position: pos,
+      },
+    ],
+    unitVariants: [
+      { unit: "m2", activatesGroupId: "g_variant_m2" },
+      { unit: "m3", activatesGroupId: "g_variant_m3", conversionFormula: "quantity / depth_m" },
+    ],
+    specialPositions: JSON.stringify({
+      quantity: { x: 100, y: 200 },
+      unitPrice: { x: 700, y: 200 },
+    }),
+  });
+
+  // Add two empty groups so the unit variant lookup resolves — the evaluator
+  // uses variant groups only to decide which branch is active via activeUnit,
+  // and in this template neither branch has variant-specific formula steps,
+  // so the groups just need to exist as valid references.
+  (e2e_paving as any).groupDefs.push(
+    { id: "g_variant_m2", label: "m2 variant", memberIds: [], position: pos },
+    { id: "g_variant_m3", label: "m3 variant", memberIds: [], position: pos }
+  );
+
+  await e2e_paving.save();
+  return { e2e_paving };
+};
+
+export default createRateBuildupTemplates;

--- a/server/src/testing/documents/tenderPricing.ts
+++ b/server/src/testing/documents/tenderPricing.ts
@@ -1,0 +1,180 @@
+import {
+  Tender,
+  TenderDocument,
+  TenderPricingSheet,
+  TenderPricingSheetDocument,
+} from "@models";
+import _ids from "@testing/_ids";
+import { TenderPricingRowType } from "@typescript/tenderPricingSheet";
+
+export interface SeededTenderPricing {
+  tender: TenderDocument;
+  sheet: TenderPricingSheetDocument;
+}
+
+/**
+ * Seed one tender + pricing sheet + one Item row with a RateBuildupSnapshot
+ * already attached. The snapshot mirrors the E2E Paving Test template seeded
+ * in rateBuildupTemplates.ts and starts with defaults (depth 0.05, waste off,
+ * unit m2). The row's unitPrice is pre-computed using the same math as
+ * evaluateSnapshot so the initial page load shows a sensible number without
+ * requiring a client-side recompute.
+ */
+const createTenderPricing = async (): Promise<SeededTenderPricing> => {
+  const pos = { x: 0, y: 0 };
+
+  const tender = new Tender({
+    _id: _ids.tenders.e2e_pricing._id,
+    name: "E2E Pricing Tender",
+    jobcode: "E2E-PRICE-001",
+    status: "bidding",
+    files: [],
+    notes: [],
+    createdBy: _ids.users.admin_user._id,
+  });
+  await tender.save();
+
+  // Build the snapshot as a JSON string — same shape as CanvasDocument + the
+  // snapshot-specific params/tables/controllers/outputs fields. Must match the
+  // template in rateBuildupTemplates.ts for evaluateSnapshot to produce the
+  // expected numbers documented there.
+  const snapshot = {
+    id: _ids.rateBuildupTemplates.e2e_paving._id.toString(),
+    sourceTemplateId: _ids.rateBuildupTemplates.e2e_paving._id.toString(),
+    label: "E2E Paving Test",
+    defaultUnit: "m2",
+    parameterDefs: [
+      { id: "depth_m", label: "Depth (m)", defaultValue: 0.05, position: pos },
+      { id: "price_per_t", label: "$/t", defaultValue: 120, position: pos },
+      { id: "labour_lump", label: "Labour Lump $", defaultValue: 5000, position: pos },
+    ],
+    tableDefs: [],
+    formulaSteps: [
+      { id: "mat_per_unit", label: "Material per unit", formula: "depth_m * 2.4 * price_per_t", position: pos },
+      { id: "lab_per_unit", label: "Labour per unit", formula: "labour_lump / quantity", position: pos },
+      { id: "waste_per_unit", label: "Waste per unit", formula: "1.5", position: pos },
+      { id: "mat_tons_total", label: "Material tons (row total)", formula: "quantity * depth_m * 2.4", position: pos },
+      { id: "crew_hours_total", label: "Crew hours (row total)", formula: "quantity * 0.02", position: pos },
+    ],
+    breakdownDefs: [
+      { id: "bd_material", label: "Material", items: [{ stepId: "mat_per_unit", label: "Material" }], position: pos },
+      { id: "bd_labour", label: "Labour", items: [{ stepId: "lab_per_unit", label: "Labour" }], position: pos },
+      { id: "bd_waste", label: "Waste", items: [{ stepId: "waste_per_unit", label: "Waste" }], position: pos },
+    ],
+    outputDefs: [
+      {
+        id: "out_asphalt",
+        kind: "Material",
+        sourceStepId: "mat_tons_total",
+        unit: "t",
+        label: "Asphalt",
+        allowedMaterialIds: [
+          _ids.materials.material_1._id.toString(),
+          _ids.materials.material_2._id.toString(),
+        ],
+        defaultMaterialId: _ids.materials.material_1._id.toString(),
+        position: pos,
+      },
+      {
+        id: "out_crew",
+        kind: "CrewHours",
+        sourceStepId: "crew_hours_total",
+        unit: "hr",
+        label: "Operator",
+        allowedCrewKindIds: [
+          _ids.crewKinds.e2e_operator._id.toString(),
+          _ids.crewKinds.e2e_labour._id.toString(),
+        ],
+        defaultCrewKindId: _ids.crewKinds.e2e_operator._id.toString(),
+        position: pos,
+      },
+    ],
+    controllerDefs: [
+      { id: "waste_toggle", label: "Include Waste", type: "toggle", defaultValue: 0, position: pos },
+    ],
+    groupDefs: [
+      {
+        id: "g_waste",
+        label: "Waste group",
+        memberIds: ["waste_per_unit"],
+        activation: { controllerId: "waste_toggle", condition: "=== 1" },
+        position: pos,
+      },
+      { id: "g_variant_m2", label: "m2 variant", memberIds: [], position: pos },
+      { id: "g_variant_m3", label: "m3 variant", memberIds: [], position: pos },
+    ],
+    unitVariants: [
+      { unit: "m2", activatesGroupId: "g_variant_m2" },
+      { unit: "m3", activatesGroupId: "g_variant_m3", conversionFormula: "quantity / depth_m" },
+    ],
+    specialPositions: {
+      quantity: { x: 100, y: 200 },
+      unitPrice: { x: 700, y: 200 },
+    },
+    // Snapshot-specific fields
+    params: { depth_m: 0.05, price_per_t: 120, labour_lump: 5000 },
+    tables: {},
+    controllers: { waste_toggle: false },
+    outputs: {
+      out_asphalt: { materialId: _ids.materials.material_1._id.toString() },
+      out_crew: { crewKindId: _ids.crewKinds.e2e_operator._id.toString() },
+    },
+  };
+
+  // Pre-computed unit price for defaults, qty 100, unit m2, waste off:
+  //   mat_per_unit  = 0.05 * 2.4 * 120        = 14.4
+  //   lab_per_unit  = 5000 / 100              = 50
+  //   waste_per_unit = 0 (group inactive)
+  //   unitPrice     = 64.4
+  const initialUnitPrice = 64.4;
+  const initialOutputs = [
+    {
+      kind: "Material",
+      materialId: _ids.materials.material_1._id,
+      unit: "t",
+      // mat_tons_total = 100 * 0.05 * 2.4 = 12
+      perUnitValue: 12,
+      totalValue: 12,
+    },
+    {
+      kind: "CrewHours",
+      crewKindId: _ids.crewKinds.e2e_operator._id,
+      unit: "hr",
+      // crew_hours_total = 100 * 0.02 = 2
+      perUnitValue: 2,
+      totalValue: 2,
+    },
+  ];
+
+  const sheet = new TenderPricingSheet({
+    _id: _ids.tenders.e2e_pricing.sheetId,
+    tender: tender._id,
+    defaultMarkupPct: 15,
+    rows: [
+      {
+        _id: _ids.tenders.e2e_pricing.rowId,
+        type: TenderPricingRowType.Item,
+        sortOrder: 0,
+        itemNumber: "1",
+        description: "E2E Paving Row",
+        indentLevel: 0,
+        quantity: 100,
+        unit: "m2",
+        unitPrice: initialUnitPrice,
+        rateBuildupSnapshot: JSON.stringify(snapshot),
+        rateBuildupOutputs: initialOutputs,
+        docRefs: [],
+        status: "not_started",
+      },
+    ],
+  });
+  await sheet.save();
+
+  // Link the sheet back to the tender for downstream queries that use the ref.
+  tender.pricingSheet = sheet._id as any;
+  await tender.save();
+
+  return { tender, sheet };
+};
+
+export default createTenderPricing;

--- a/server/src/testing/documents/tenderPricing.ts
+++ b/server/src/testing/documents/tenderPricing.ts
@@ -47,12 +47,13 @@ const createTenderPricing = async (): Promise<SeededTenderPricing> => {
       { id: "depth_m", label: "Depth (m)", defaultValue: 0.05, position: pos },
       { id: "price_per_t", label: "$/t", defaultValue: 120, position: pos },
       { id: "labour_lump", label: "Labour Lump $", defaultValue: 5000, position: pos },
+      { id: "waste_rate", label: "Waste $/unit", defaultValue: 1.5, position: pos },
     ],
     tableDefs: [],
     formulaSteps: [
       { id: "mat_per_unit", label: "Material per unit", formula: "depth_m * 2.4 * price_per_t", position: pos },
       { id: "lab_per_unit", label: "Labour per unit", formula: "labour_lump / quantity", position: pos },
-      { id: "waste_per_unit", label: "Waste per unit", formula: "1.5", position: pos },
+      { id: "waste_per_unit", label: "Waste per unit", formula: "waste_rate", position: pos },
       { id: "mat_tons_total", label: "Material tons (row total)", formula: "quantity * depth_m * 2.4", position: pos },
       { id: "crew_hours_total", label: "Crew hours (row total)", formula: "quantity * 0.02", position: pos },
     ],
@@ -96,7 +97,7 @@ const createTenderPricing = async (): Promise<SeededTenderPricing> => {
       {
         id: "g_waste",
         label: "Waste group",
-        memberIds: ["waste_per_unit"],
+        memberIds: ["waste_rate", "waste_per_unit"],
         activation: { controllerId: "waste_toggle", condition: "=== 1" },
         position: pos,
       },
@@ -112,7 +113,7 @@ const createTenderPricing = async (): Promise<SeededTenderPricing> => {
       unitPrice: { x: 700, y: 200 },
     },
     // Snapshot-specific fields
-    params: { depth_m: 0.05, price_per_t: 120, labour_lump: 5000 },
+    params: { depth_m: 0.05, price_per_t: 120, labour_lump: 5000, waste_rate: 1.5 },
     tables: {},
     controllers: { waste_toggle: false },
     outputs: {

--- a/server/src/testing/seedDatabase.ts
+++ b/server/src/testing/seedDatabase.ts
@@ -26,6 +26,13 @@ import createSignups, { SeededSignups } from "./documents/signups";
 import createUsers, { SeededUsers } from "./documents/users";
 import createVehicles, { SeededVehicles } from "./documents/vehicles";
 import createVehicleWork, { SeededVehicleWork } from "./documents/vehicleWork";
+import createCrewKinds, { SeededCrewKinds } from "./documents/crewKinds";
+import createRateBuildupTemplates, {
+  SeededRateBuildupTemplates,
+} from "./documents/rateBuildupTemplates";
+import createTenderPricing, {
+  SeededTenderPricing,
+} from "./documents/tenderPricing";
 
 export interface SeededDatabase {
   companies: SeededCompanies;
@@ -45,6 +52,9 @@ export interface SeededDatabase {
   users: SeededUsers;
   vehicles: SeededVehicles;
   vehicleWork: SeededVehicleWork;
+  crewKinds: SeededCrewKinds;
+  rateBuildupTemplates: SeededRateBuildupTemplates;
+  tenderPricing: SeededTenderPricing;
 }
 
 const seedDatabase = async () => {
@@ -76,6 +86,11 @@ const seedDatabase = async () => {
   const vehicles = await createVehicles();
   const vehicleWork = await createVehicleWork();
 
+  // Tender pricing E2E fixtures — depend on materials and users seeded above.
+  const crewKinds = await createCrewKinds();
+  const rateBuildupTemplates = await createRateBuildupTemplates();
+  const tenderPricing = await createTenderPricing();
+
   console.log("seeded");
 
   return {
@@ -96,6 +111,9 @@ const seedDatabase = async () => {
     users,
     vehicles,
     vehicleWork,
+    crewKinds,
+    rateBuildupTemplates,
+    tenderPricing,
   };
 };
 


### PR DESCRIPTION
## Summary

Three independent fixes bundled into this deploy:

1. **Tender pricing test suite + evaluator parity fix** — comprehensive test coverage plus a production bug in the snapshot evaluator.
2. **iOS PWA white screen on home-screen launch** — fresh iPhone "Save as Web App" installs opened to a white screen.
3. **Tender enriched files looping Ready→Processing on large batches** — a user added ~60 files to a tender and every file endlessly cycled from Ready to Processing, burning Claude tokens.

---

## 1. Tender pricing test suite + evaluator fix

Comprehensive test coverage for the tender pricing system plus a production bug fix for the snapshot evaluator.

### Tests added
- **113 client Vitest tests** covering the pure evaluator math:
  - `evaluateTemplate` — formulas, parameters, tables, breakdowns, output nodes, controllers, inactive nodes, circular dependencies, edge cases
  - `evaluateSnapshot` — variants, controllers, outputs, multi-output mixed kinds, variant × controller interaction
  - `isGroupActive` + `computeInactiveNodeIds` — all controller types + comparison operators + parent propagation + unit variant groups
  - `fragmentToDoc` — specialPositions parsing, legacy groupDefs/controllerDefs JSON, dedup
  - `snapshotFromTemplate` + `snapshotToCanvasDoc` — params/tables/controllers/outputs seeding, legacy outputDefs fallback
  - Quantity-dependent unit price (`/ quantity` convention) — fixed costs amortised across quantity
- **22 new server Vitest tests** for CrewKind CRUD, RateBuildupTemplate save validation (whitelist/default invariants), TenderPricingSheet row update (kind↔field validation, snapshot+outputs persistence)
- **5 Playwright E2E specs** proving the full UI → Apollo → server → DB → reload wire: initial load, param change + reload persistence, unit variant m2↔m3, waste toggle, output material picker

### Seed fixtures
New factories in `server/src/testing/documents/`:
- `crewKinds.ts` — 2 test CrewKinds (E2E Operator, E2E Labour)
- `rateBuildupTemplates.ts` — "E2E Paving Test" template exercising every wire path (3 params, 5 formula steps, 3 breakdowns, Material+CrewHours outputs, toggle controller gating a group, m2/m3 unit variants)
- `tenderPricing.ts` — tender + pricing sheet + item row with snapshot attached

Also extends `clearDatabase` to drop the new collections on reseed.

### Production bug fix
**`evaluateSnapshot` + `RateBuildupInputs` disagreed on controller defaults** when a template defined controllers and referenced them in formula steps but the saved snapshot's `controllers` object was empty. The save path built its numeric context from `Object.entries(snapshot.controllers)` — skipping every defined controller — while the live preview iterated `doc.controllerDefs`. Formula steps referencing controller ids crashed to 0 via safeEval on the save path only. Displayed unit price was correct; persisted value was silently wrong until reload.

Fixed by extracting `evaluateCanvasDoc` — a single shared helper used by both `evaluateSnapshot` (save path) and `RateBuildupInputs` (live preview). Quantity normalization, controller context construction, and inactive-node computation now have one canonical implementation. Drift between the two paths is impossible by construction.

As a bonus, also fixes a latent `RateBuildupInputs` bug where unset percentage/toggle controllers fell back to `0` instead of each def's `defaultValue`, diverging from `isGroupActive`'s semantics. Templates relying on non-zero controller defaults will now display the correct live-preview unit price even when the user has never touched the inputs.

### Other fixes
- Missing `await` on 10 `TenderPricingSheetClass` mutation method calls in the resolver — synchronous throws were becoming unhandled rejections rather than surfacing as GraphQL errors
- `fragmentToDoc` extracted from `canvasStorage.ts` into its own file so unit tests can import it without pulling in React
- CI `test-client-ct` job now runs `npm run test` (Vitest) before the Playwright component tests — catches unit failures before the Chromium download

---

## 2. iOS PWA white screen on home-screen launch

Users reported that iPhones installing the app via Safari "Save as Web App" launched to a white screen on every open. Reproduces on fresh installs — rules out stale service worker state.

### Root cause
- `public/manifest.json` used `"display": "fullscreen"`. iOS Safari does **not** support `fullscreen` display mode — only `standalone` / `minimal-ui` / `browser`. Fallback behaviour across iOS versions is inconsistent.
- `_document.tsx` was missing the iOS-required meta tags for standalone home-screen mode: `apple-mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style`, `apple-mobile-web-app-title`.

### Fix
- `client/public/manifest.json`, `manifest-paving.json`, `manifest-concrete.json` — `fullscreen` → `standalone`. All three variants updated because `ci.yml` / `build-deploy.yml` overwrite `manifest.json` from the paving/concrete variant at build time per app, so patching only the runtime file would be reverted on deploy.
- `client/src/pages/_document.tsx` — add `apple-mobile-web-app-capable=yes`, `apple-mobile-web-app-status-bar-style=black-translucent`, `apple-mobile-web-app-title` (per-variant via `NEXT_PUBLIC_APP_NAME`).

### Explicitly not in scope
- **next-pwa service worker cache tweaks** — ruled out by the fresh-install repro; no prior SW state to stale.
- **AuthProvider redirect / splash state** — same reason; leaving the recent blank-screen class of fixes alone.

---

## 3. Tender enriched files looping Ready→Processing on large batches

A user uploaded ~60 files to a tender and every file endlessly cycled from Ready → Processing → Ready in the UI, burning Claude tokens on each cycle. Consumer has been scaled to 0 in prod to stop the bleeding.

### Root cause — two bugs interact

**Bug 1: Watchdog republishes legitimately-waiting pending files.**
`server/src/consumer/index.ts` considered any file in `"pending"` with `createdAt < 10 min ago` to be "stuck". 60 files × `prefetch=2` × 2–5 min per file = 1–2.5 hours to drain. At the 10-min watchdog tick, ~50 files were still legitimately waiting in the queue, and the watchdog republished every one of them. Next tick: more duplicates. `createdAt` never ages, so nothing ever escaped the "stuck" window.

**Bug 2: Handler was non-idempotent.**
`server/src/consumer/handlers/enrichedFileSummaryHandler.ts` unconditionally set `summaryStatus: "processing"` at entry. A duplicate message for an already-`ready` file flipped it back to `processing` and re-ran: re-download from S3, re-call Claude Haiku, re-build page index. **This is exactly what the UI showed — "Ready → Processing" cycling.**

### Fix

- **`EnrichedFile` schema** — add `queuedAt?: Date`. Stamped by `publishEnrichedFileCreated` on every publish (via a raw MongoDB collection write to avoid importing `@models` from the publisher, which would close a circular import loop with post-save hooks in other models).
- **Watchdog `stuckPending` check** now uses `queuedAt < pendingCutoff` with a `createdAt` fallback for legacy docs. `PENDING_STUCK_MS` raised from 10 min to 3 hr so large batch uploads have comfortable headroom.
- **Handler idempotency guard** at entry:
  - Missing / `ready` / `failed` → skip & ack (stale duplicate).
  - `processing` with `processingStartedAt` within the 90 min ownership window → skip & ack (another handler owns it).
  - Otherwise → take ownership and proceed.
  Duplicates become cheap no-ops instead of re-runs.
- **New one-off script `server/src/scripts/reset-stuck-enriched-files.ts`** to recover files left in pending/processing/failed state from the incident. Flags: `--tender <id>`, `--status <list>`, `--id <id>`, `--dry-run`.

### Explicitly not in scope
- Rate-limit sleep-in-handler (`enrichedFileSummaryHandler.ts:174-194`) still blocks a prefetch slot for 2–8 min on Claude 429s. Wasteful but not a loop driver — defer.

### Deploy + recovery plan

After this PR lands on production:

1. **Purge queue duplicates from the incident** (consumer is already at 0 replicas so nothing consumes during purge):
   ```
   kubectl config use-context do-tor...   # verify with: kubectl config current-context
   kubectl exec -it $(kubectl get pod -l app=rabbitmq -o jsonpath='{.items[0].metadata.name}') -- rabbitmqctl purge_queue enriched.file_summary
   ```
2. **Deploy** (this PR merged → master→production flow picks up the new image).
3. **Scale consumer back to 1 replica**:
   ```
   kubectl scale deployment/consumer-deployment --replicas=1
   ```
4. **Run the reset script** in a one-off pod against the affected tender (replace `<tender-id>`):
   ```
   kubectl run reset-stuck --rm -it --restart=Never \
     --image=<same-as-consumer-image> \
     --env="MONGO_URI=$(kubectl get secret <mongo-secret> -o jsonpath='{.data.uri}' | base64 -d)" \
     --env="RABBITMQ_URL=..." \
     -- npx ts-node -r tsconfig-paths/register src/scripts/reset-stuck-enriched-files.ts --tender <tender-id> --dry-run
   ```
   Remove `--dry-run` once the log output looks right.
5. **Watch consumer logs** for the expected flow:
   ```
   [EnrichedFileSummary] Processing file ... (attempt 0)
   [EnrichedFileSummary] Done for file ...
   ```
   No more `[EnrichedFileSummary] File ... already ready — skipping duplicate` should appear after the queue purge.

---

## Test plan

### Tender pricing
- [ ] Verify deployed server pod comes up cleanly
- [ ] On a real legacy tender with a rate buildup row, open the detail pane and confirm the unit price matches the displayed breakdown
- [ ] Change a param in the buildup inputs, wait for debounced save, close + reopen detail — unit price should persist correctly
- [ ] Toggle a controller-gated group — unit price should update and persist across reload
- [ ] Switch a row's unit variant — price should recompute via conversion formula and persist
- [ ] Confirm the previously broken row (with empty snapshot.controllers but controllers referenced in formulas) now saves the correct unit price instead of the defaults-only value
- [ ] Check canary logs for any new evaluator-related errors

### iOS PWA
- [ ] On a clean iPhone Safari session after deploy: visit the production URL, tap Share → Add to Home Screen
- [ ] Launch the installed app from the home screen; verify it opens into the app shell (not a white screen)
- [ ] Verify the home-screen app title reflects the variant (Bow Mark Paving vs Bow Mark Concrete)
- [ ] Verify the status bar displays in standalone style (no Safari chrome)
- [ ] Confirm no regression on Android — existing PWA install flow still works

### Enriched files loop
- [ ] Purge `enriched.file_summary` queue in prod RabbitMQ before scaling consumer back up
- [ ] Scale `consumer-deployment` back to 1
- [ ] Run `reset-stuck-enriched-files.ts --tender <id> --dry-run`, review output, then re-run without `--dry-run`
- [ ] Watch consumer logs — files should transition pending → processing → ready without any Ready → Processing flip messages
- [ ] Upload a new batch of ~10 files to a test tender and verify they all settle to Ready within a few minutes
- [ ] Verify watchdog does not republish any file whose `queuedAt` is fresh (log line: `[Watchdog] Found stuck files — processing: 0, pending: 0, failed: 0`)
- [ ] Confirm the affected tender's file list shows all 60 files as Ready and the tender summary regeneration kicked in

🤖 Generated with [Claude Code](https://claude.com/claude-code)