### PR TITLE
Deploy: tender document organization

### DIFF
--- a/client/src/components/Tender/TenderDocuments.tsx
+++ b/client/src/components/Tender/TenderDocuments.tsx
@@ -671,21 +671,19 @@ const TenderDocuments = ({ tender, onUpdated, onFileSelect }: TenderDocumentsPro
         />
       </Box>
 
-      {/* File list — scrollable */}
-      <Box flex={1} overflowY="auto" px={5} py={3}>
-        {hasPending && (
-          <Alert status="warning" mb={3} borderRadius="md" size="sm">
-            <AlertIcon />
-            <AlertDescription fontSize="sm">
-              {pendingCount} {pendingCount === 1 ? "document is" : "documents are"} still being processed — answers may be incomplete.
-            </AlertDescription>
-          </Alert>
-        )}
-
-        {/* Search bar — shown when there's more than one file. Filters
-            across filename, AI document type, key topics, and overview. */}
-        {tender.files.length > 1 && (
-          <InputGroup size="sm" mb={3}>
+      {/* Search bar — pinned below the upload area. Shown when there's
+          more than one file. Filters across filename, AI document type,
+          key topics, and overview. */}
+      {tender.files.length > 1 && (
+        <Box
+          px={5}
+          py={2}
+          borderBottom="1px solid"
+          borderColor="gray.200"
+          flexShrink={0}
+          bg="white"
+        >
+          <InputGroup size="sm">
             <InputLeftElement pointerEvents="none" color="gray.400">
               <FiSearch />
             </InputLeftElement>
@@ -708,6 +706,18 @@ const TenderDocuments = ({ tender, onUpdated, onFileSelect }: TenderDocumentsPro
               </InputRightElement>
             )}
           </InputGroup>
+        </Box>
+      )}
+
+      {/* File list — scrollable */}
+      <Box flex={1} overflowY="auto" px={5} py={3}>
+        {hasPending && (
+          <Alert status="warning" mb={3} borderRadius="md" size="sm">
+            <AlertIcon />
+            <AlertDescription fontSize="sm">
+              {pendingCount} {pendingCount === 1 ? "document is" : "documents are"} still being processed — answers may be incomplete.
+            </AlertDescription>
+          </Alert>
         )}
 
         {tender.files.length === 0 ? (

--- a/client/src/components/Tender/TenderDocuments.tsx
+++ b/client/src/components/Tender/TenderDocuments.tsx
@@ -1,4 +1,9 @@
 import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
   Alert,
   AlertDescription,
   AlertIcon,
@@ -8,6 +13,10 @@ import {
   Collapse,
   HStack,
   IconButton,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  InputRightElement,
   Spinner,
   Text,
   Tooltip,
@@ -19,7 +28,15 @@ import {
 import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
 import React from "react";
-import { FiChevronDown, FiChevronRight, FiExternalLink, FiRefreshCw, FiTrash2 } from "react-icons/fi";
+import {
+  FiChevronDown,
+  FiChevronRight,
+  FiExternalLink,
+  FiRefreshCw,
+  FiSearch,
+  FiTrash2,
+  FiX,
+} from "react-icons/fi";
 import { TenderDetail, TenderFileItem } from "./types";
 import dataUrlToBlob from "../../utils/dataUrlToBlob";
 import { collectDroppedFiles } from "../../utils/collectDroppedFiles";
@@ -361,8 +378,70 @@ const TenderDocuments = ({ tender, onUpdated, onFileSelect }: TenderDocumentsPro
   const [removingId, setRemovingId] = React.useState<string | null>(null);
   const [retryingId, setRetryingId] = React.useState<string | null>(null);
   const [isDragOver, setIsDragOver] = React.useState(false);
+  const [searchQuery, setSearchQuery] = React.useState("");
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const folderInputRef = React.useRef<HTMLInputElement>(null);
+
+  // Case-insensitive substring match over filename, AI documentType, key
+  // topics, and the summary overview. Overview is included so a user
+  // searching for "temperature" finds a spec book whose per-page index
+  // hasn't been loaded yet — the high-level summary still mentions it.
+  const filteredFiles = React.useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return tender.files;
+    return tender.files.filter((f) => {
+      const filename = (f.file.description ?? "").toLowerCase();
+      if (filename.includes(q)) return true;
+      const docType = (f.summary?.documentType ?? f.documentType ?? "").toLowerCase();
+      if (docType.includes(q)) return true;
+      const topics = (f.summary?.keyTopics ?? []).join(" ").toLowerCase();
+      if (topics.includes(q)) return true;
+      const overview = (f.summary?.overview ?? "").toLowerCase();
+      if (overview.includes(q)) return true;
+      return false;
+    });
+  }, [tender.files, searchQuery]);
+
+  // Group filtered files by AI-generated category. Returns null when no
+  // categories exist yet (newly-uploaded tender before the first
+  // categorization pass) — the caller falls back to a flat list.
+  //
+  // Categories come server-side in display order (most-accessed first).
+  // Files not claimed by any category land in the "Uncategorized" bucket
+  // at the end; empty buckets are dropped so search results stay tight.
+  const groupedFiles = React.useMemo(() => {
+    const categories = tender.fileCategories ?? [];
+    if (categories.length === 0) return null;
+
+    const sortedCategories = [...categories].sort((a, b) => a.order - b.order);
+    const fileById = new Map(filteredFiles.map((f) => [f._id, f]));
+
+    const groups: Array<{
+      _id: string;
+      name: string;
+      files: TenderFileItem[];
+    }> = [];
+    const claimed = new Set<string>();
+
+    for (const cat of sortedCategories) {
+      const files = cat.fileIds
+        .map((id) => fileById.get(id))
+        .filter((f): f is TenderFileItem => f !== undefined);
+      files.forEach((f) => claimed.add(f._id));
+      groups.push({ _id: cat._id, name: cat.name, files });
+    }
+
+    const uncategorized = filteredFiles.filter((f) => !claimed.has(f._id));
+    if (uncategorized.length > 0) {
+      groups.push({
+        _id: "uncategorized",
+        name: "Uncategorized",
+        files: uncategorized,
+      });
+    }
+
+    return groups.filter((g) => g.files.length > 0);
+  }, [filteredFiles, tender.fileCategories]);
 
   React.useEffect(() => {
     folderInputRef.current?.setAttribute("webkitdirectory", "");
@@ -603,9 +682,98 @@ const TenderDocuments = ({ tender, onUpdated, onFileSelect }: TenderDocumentsPro
           </Alert>
         )}
 
-        {tender.files.length > 0 ? (
+        {/* Search bar — shown when there's more than one file. Filters
+            across filename, AI document type, key topics, and overview. */}
+        {tender.files.length > 1 && (
+          <InputGroup size="sm" mb={3}>
+            <InputLeftElement pointerEvents="none" color="gray.400">
+              <FiSearch />
+            </InputLeftElement>
+            <Input
+              placeholder="Search documents…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              borderRadius="md"
+              bg="white"
+            />
+            {searchQuery && (
+              <InputRightElement>
+                <IconButton
+                  aria-label="Clear search"
+                  icon={<FiX />}
+                  size="xs"
+                  variant="ghost"
+                  onClick={() => setSearchQuery("")}
+                />
+              </InputRightElement>
+            )}
+          </InputGroup>
+        )}
+
+        {tender.files.length === 0 ? (
+          <Text fontSize="sm" color="gray.500">
+            No documents yet.
+          </Text>
+        ) : filteredFiles.length === 0 ? (
+          <Text fontSize="sm" color="gray.500">
+            No documents match &ldquo;{searchQuery}&rdquo;.
+          </Text>
+        ) : groupedFiles && groupedFiles.length > 0 ? (
+          // Grouped view — AI-categorized folders. All open by default;
+          // user can collapse individual sections. Order comes from the
+          // server (most-accessed folder first).
+          <Accordion
+            allowMultiple
+            defaultIndex={groupedFiles.map((_, i) => i)}
+            // Force re-mount when the group count changes so newly-added
+            // folders default to expanded. Without this, Accordion holds
+            // onto its original defaultIndex across re-renders.
+            key={groupedFiles.length}
+          >
+            {groupedFiles.map((group) => (
+              <AccordionItem key={group._id} border="none" mb={2}>
+                <AccordionButton
+                  px={2}
+                  py={1}
+                  borderRadius="md"
+                  _hover={{ bg: "gray.100" }}
+                >
+                  <Box flex="1" textAlign="left">
+                    <HStack spacing={2}>
+                      <Text fontSize="sm" fontWeight="semibold" color="gray.700">
+                        {group.name}
+                      </Text>
+                      <Text fontSize="xs" color="gray.400">
+                        {group.files.length}
+                      </Text>
+                    </HStack>
+                  </Box>
+                  <AccordionIcon color="gray.400" />
+                </AccordionButton>
+                <AccordionPanel px={0} pb={2} pt={1}>
+                  <VStack spacing={2} align="stretch">
+                    {group.files.map((file) => (
+                      <FileCard
+                        key={file._id}
+                        file={file}
+                        tenderId={tender._id}
+                        onRemove={handleRemove}
+                        onRetry={handleRetry}
+                        removingId={removingId}
+                        retryingId={retryingId}
+                        onFileSelect={onFileSelect}
+                      />
+                    ))}
+                  </VStack>
+                </AccordionPanel>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        ) : (
+          // Flat list — either no categories yet (first upload before
+          // categorizer has run) or categorizer returned nothing usable.
           <VStack spacing={2} align="stretch">
-            {tender.files.map((file) => (
+            {filteredFiles.map((file) => (
               <FileCard
                 key={file._id}
                 file={file}
@@ -618,10 +786,6 @@ const TenderDocuments = ({ tender, onUpdated, onFileSelect }: TenderDocumentsPro
               />
             ))}
           </VStack>
-        ) : (
-          <Text fontSize="sm" color="gray.500">
-            No documents yet.
-          </Text>
         )}
       </Box>
     </Box>

--- a/client/src/components/Tender/types.ts
+++ b/client/src/components/Tender/types.ts
@@ -69,6 +69,16 @@ export interface TenderJobSummary {
   generatedFrom: string[];
 }
 
+// AI-generated document folder. Populated by the server-side categorizer
+// (lib/categorizeTenderFiles). `fileIds` references TenderFileItem._id.
+// Order is descending by typical-access-frequency during estimation.
+export interface TenderFileCategory {
+  _id: string;
+  name: string;
+  order: number;
+  fileIds: string[];
+}
+
 export interface TenderDetail {
   _id: string;
   name: string;
@@ -76,6 +86,7 @@ export interface TenderDetail {
   status: string;
   description?: string | null;
   files: TenderFileItem[];
+  fileCategories?: TenderFileCategory[] | null;
   notes: TenderNote[];
   summaryGenerating: boolean;
   jobSummary?: TenderJobSummary | null;

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -3075,6 +3075,7 @@ export type TenderClass = {
   createdAt: Scalars['DateTime'];
   createdBy: UserClass;
   description?: Maybe<Scalars['String']>;
+  fileCategories?: Maybe<Array<TenderFileCategoryClass>>;
   files: Array<EnrichedFileClass>;
   jobcode: Scalars['String'];
   jobsite?: Maybe<JobsiteClass>;
@@ -3090,6 +3091,14 @@ export type TenderCreateData = {
   description?: InputMaybe<Scalars['String']>;
   jobcode: Scalars['String'];
   name: Scalars['String'];
+};
+
+export type TenderFileCategoryClass = {
+  __typename?: 'TenderFileCategoryClass';
+  _id: Scalars['ID'];
+  fileIds: Array<Scalars['ID']>;
+  name: Scalars['String'];
+  order: Scalars['Float'];
 };
 
 export type TenderJobSummaryClass = {

--- a/client/src/pages/tender/[id]/index.tsx
+++ b/client/src/pages/tender/[id]/index.tsx
@@ -116,6 +116,12 @@ const TENDER_QUERY = gql`
           description
         }
       }
+      fileCategories {
+        _id
+        name
+        order
+        fileIds
+      }
       notes {
         _id
         content

--- a/server/src/consumer/handlers/enrichedFileSummaryHandler.ts
+++ b/server/src/consumer/handlers/enrichedFileSummaryHandler.ts
@@ -13,6 +13,7 @@ import {
 } from "./summarizePdf";
 import { publishEnrichedFileCreated } from "../../rabbitmq/publisher";
 import { scheduleTenderSummary } from "../../lib/generateTenderSummary";
+import { scheduleCategorization } from "../../lib/categorizeTenderFiles";
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
@@ -444,13 +445,25 @@ export const enrichedFileSummaryHandler = {
 
       console.log(`[EnrichedFileSummary] Done for file ${fileId}`);
 
-      // ── Trigger tender summary ──────────────────────────────────────
-      // Fires when every file on the parent tender has reached a terminal
-      // success state. Partial files are still in-flight (watchdog will
-      // retry), so they block tender summary regeneration.
+      // ── Trigger tender-level regeneration ───────────────────────────
+      // Two things piggyback on a file reaching ready:
+      //   1. Tender summary — only when every file on the tender has
+      //      reached a terminal success state (partial/pending/processing
+      //      all block it, because they'll still change the summary)
+      //   2. Document categorization — on every file transition, 60s
+      //      debounced. Burst uploads collapse into one Claude call.
+      //      Partial files don't block categorization because they
+      //      already have a usable summary.
       try {
         const tender = await Tender.findOne({ files: enrichedFileId }).lean();
         if (tender) {
+          const tenderIdStr = (tender as any)._id.toString();
+
+          // Always schedule categorization — the debounce ensures we
+          // don't thrash on batch uploads, and a new file is exactly
+          // when the folder structure may need to change.
+          scheduleCategorization(tenderIdStr);
+
           const fileIds = ((tender as any).files as any[]).map((f: any) =>
             f._id ? f._id.toString() : f.toString()
           );
@@ -462,14 +475,14 @@ export const enrichedFileSummaryHandler = {
           });
           if (pendingCount === 0) {
             console.log(
-              `[EnrichedFileSummary] All tender files ready — scheduling summary for tender ${(tender as any)._id}`
+              `[EnrichedFileSummary] All tender files ready — scheduling summary for tender ${tenderIdStr}`
             );
-            scheduleTenderSummary((tender as any)._id.toString());
+            scheduleTenderSummary(tenderIdStr);
           }
         }
       } catch (triggerErr) {
         console.warn(
-          "[EnrichedFileSummary] Tender summary trigger check failed:",
+          "[EnrichedFileSummary] Tender-level trigger check failed:",
           triggerErr
         );
       }

--- a/server/src/lib/categorizeTenderFiles.ts
+++ b/server/src/lib/categorizeTenderFiles.ts
@@ -1,0 +1,220 @@
+/**
+ * Tender document categorizer — groups a tender's uploaded files into
+ * AI-chosen folders so estimators can navigate large tenders (60+ docs).
+ *
+ * Runs on a 60s debounce triggered by new files reaching `ready` state
+ * (see the hook in enrichedFileSummaryHandler.ts). Each pass is a full
+ * re-categorization: it reads every ready/partial file on the tender,
+ * asks Claude to bucket them into a small number of folders (typically
+ * 3-7), and overwrites `tender.fileCategories` with the result.
+ *
+ * Always-full re-categorization was an intentional choice — incremental
+ * would preserve existing assignments on a single-file add, but adds
+ * prompt complexity. 60s debounce keeps the cost reasonable (one Claude
+ * call per burst of uploads, not per file).
+ *
+ * Files not present in any category's fileIds list are rendered as
+ * "Uncategorized" by the client. This covers: in-flight uploads,
+ * anything the AI dropped on the floor, and the window between upload
+ * and the next debounced run.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import mongoose from "mongoose";
+import { Tender } from "@models";
+
+// Debounce: cancel any pending auto-trigger for the same tender before
+// firing a new one. A batch upload of 30 files collapses into a single
+// Claude call, not 30 concurrent calls.
+const pendingAutoTriggers = new Map<string, ReturnType<typeof setTimeout>>();
+const AUTO_TRIGGER_DELAY_MS = 60_000;
+
+export function scheduleCategorization(tenderId: string): void {
+  const existing = pendingAutoTriggers.get(tenderId);
+  if (existing) clearTimeout(existing);
+
+  const timer = setTimeout(() => {
+    pendingAutoTriggers.delete(tenderId);
+    categorizeTenderFiles(tenderId).catch((err) =>
+      console.warn(
+        `[categorizeTenderFiles] Debounced trigger failed for ${tenderId}:`,
+        err
+      )
+    );
+  }, AUTO_TRIGGER_DELAY_MS);
+  pendingAutoTriggers.set(tenderId, timer);
+}
+
+const CATEGORIZATION_PROMPT = `You are organizing construction tender documents into logical folders for an estimator at Bow Mark, a paving and concrete company. The estimator is pricing this job and needs the documents grouped so they can quickly find what they're looking for when flipping through a tender.
+
+Rules:
+- Group every provided file into exactly one category.
+- Aim for a small number of folders — typically 3 to 7, scaled to how many files there are. Do NOT create single-file folders unless a file genuinely doesn't fit anywhere else. Err on the side of fewer, broader folders.
+- Use construction/tender-appropriate category names an estimator would immediately recognize. Examples: "Drawings", "Specifications", "Schedule of Quantities", "Addenda", "Geotechnical", "Traffic Management", "Correspondence", "Standard Details", "Permits", "Reference Documents".
+- Order the categories from MOST-OFTEN-ACCESSED first to LEAST-OFTEN-ACCESSED last during tender estimation. Drawings and the schedule of quantities are typically referenced most often while pricing a job. Addenda and correspondence are checked occasionally. Reference specs and standard details are looked up as needed. Order matters — the first category should be the one the estimator opens first.
+- Use the filename, the AI-generated document type, the overview, and the key topics to decide where each file belongs. Filenames are often the strongest signal.
+
+Return a JSON object with this exact shape:
+{
+  "categories": [
+    { "name": "Drawings", "fileIds": ["<file id 1>", "<file id 2>"] },
+    { "name": "Specifications", "fileIds": ["<file id 3>"] }
+  ]
+}
+
+Every fileId from the input list must appear in exactly one category. Return only valid JSON, no markdown, no explanation.`;
+
+export async function categorizeTenderFiles(
+  tenderId: string,
+  anthropicClient?: Pick<Anthropic, "messages">
+): Promise<void> {
+  const anthropic =
+    anthropicClient ??
+    new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  const tender = await Tender.findById(tenderId)
+    .populate({ path: "files" })
+    .lean();
+
+  if (!tender) {
+    console.warn(`[categorizeTenderFiles] Tender ${tenderId} not found`);
+    return;
+  }
+
+  // `partial` files have a completed summary (pageIndex is what's
+  // incomplete), so they have enough context to be categorized. Only
+  // skip files that haven't produced a summary yet.
+  const files = ((tender.files as any[]) ?? []).filter(
+    (f: any) => f.summaryStatus === "ready" || f.summaryStatus === "partial"
+  );
+
+  if (files.length === 0) {
+    console.log(
+      `[categorizeTenderFiles] No summarized files for tender ${tenderId} — skipping`
+    );
+    return;
+  }
+
+  // Build compact per-file context. Filename first since it's the
+  // strongest categorization signal for most construction tender docs.
+  const fileContext = files
+    .map((f: any) => {
+      const summary = f.summary as any;
+      const filename =
+        ((f.file as any)?.description as string | undefined) ??
+        `unknown-${f._id.toString()}`;
+      const lines = [
+        `- id: ${f._id.toString()}`,
+        `  filename: ${filename}`,
+        summary?.documentType
+          ? `  documentType: ${summary.documentType}`
+          : null,
+        summary?.overview ? `  overview: ${summary.overview}` : null,
+        summary?.keyTopics?.length
+          ? `  keyTopics: ${summary.keyTopics.join(", ")}`
+          : null,
+      ].filter(Boolean);
+      return lines.join("\n");
+    })
+    .join("\n\n");
+
+  const userContent = `Tender: ${(tender as any).name} (${(tender as any).jobcode})
+File count: ${files.length}
+
+## Files to categorize
+
+${fileContext}
+
+---
+
+${CATEGORIZATION_PROMPT}`;
+
+  try {
+    const response = await anthropic.messages.create({
+      model: "claude-haiku-4-5",
+      max_tokens: 2048,
+      messages: [{ role: "user", content: userContent }],
+    });
+
+    const rawText =
+      response.content[0]?.type === "text"
+        ? response.content[0].text.trim()
+        : "";
+    const cleaned = rawText
+      .replace(/^```(?:json)?\s*/i, "")
+      .replace(/\s*```$/, "")
+      .trim();
+
+    let parsed: { categories: Array<{ name: string; fileIds: string[] }> };
+    try {
+      parsed = JSON.parse(cleaned);
+    } catch {
+      console.error(
+        `[categorizeTenderFiles] Invalid JSON from Claude for tender ${tenderId}: ${rawText.slice(0, 200)}`
+      );
+      return;
+    }
+
+    if (
+      !parsed.categories ||
+      !Array.isArray(parsed.categories) ||
+      parsed.categories.length === 0
+    ) {
+      console.warn(
+        `[categorizeTenderFiles] Empty categories response for tender ${tenderId}`
+      );
+      return;
+    }
+
+    // Validate the response:
+    //   - only accept fileIds that were actually in the input
+    //   - deduplicate (first category claiming a fileId wins)
+    //   - drop empty categories (can happen if Claude assigns everything
+    //     from a proposed category to another one at output time)
+    const validFileIds = new Set(files.map((f: any) => f._id.toString()));
+    const claimed = new Set<string>();
+    const fileCategories = parsed.categories
+      .filter((c) => c && typeof c.name === "string" && Array.isArray(c.fileIds))
+      .map((cat, idx) => {
+        const fileIds = (cat.fileIds ?? [])
+          .filter((id) => typeof id === "string" && validFileIds.has(id))
+          .filter((id) => {
+            if (claimed.has(id)) return false;
+            claimed.add(id);
+            return true;
+          })
+          .map((id) => new mongoose.Types.ObjectId(id));
+        return {
+          _id: new mongoose.Types.ObjectId(),
+          name: cat.name.trim(),
+          order: idx,
+          fileIds,
+        };
+      })
+      .filter((c) => c.fileIds.length > 0);
+
+    if (fileCategories.length === 0) {
+      console.warn(
+        `[categorizeTenderFiles] All categories empty after validation for tender ${tenderId}`
+      );
+      return;
+    }
+
+    await (Tender as any).findByIdAndUpdate(tenderId, {
+      $set: { fileCategories },
+    });
+
+    const uncategorizedCount = validFileIds.size - claimed.size;
+    console.log(
+      `[categorizeTenderFiles] Categorized ${files.length} files into ${fileCategories.length} folders for tender ${tenderId}` +
+        (uncategorizedCount > 0
+          ? ` (${uncategorizedCount} left uncategorized)`
+          : "")
+    );
+  } catch (error) {
+    console.error(
+      `[categorizeTenderFiles] Failed for tender ${tenderId}:`,
+      error
+    );
+    throw error;
+  }
+}

--- a/server/src/lib/readDocumentExecutor.ts
+++ b/server/src/lib/readDocumentExecutor.ts
@@ -67,6 +67,34 @@ const PDF_PAGE_LIMIT = 90; // conservative buffer below Anthropic's 100-page har
  *                   `_id`, `file` (ref or populated object with `_id`),
  *                   `documentType`, `summary?.documentType`, `pageCount`
  */
+/**
+ * Build the display label for a file. Prefers the original uploaded
+ * filename (stored on the File ref's `description` field), falling back
+ * to the AI-generated documentType only if the filename isn't present.
+ *
+ * The old behavior used summary.documentType first, which was confusing
+ * — Claude's tool log would say "Loaded document: Schedule of Quantities
+ * with Letter of Intent" when the actual file was named
+ * "SchedOfQty_T123.pdf". Users citing or referencing the doc had no way
+ * to match the label against what they'd uploaded.
+ */
+function buildFileLabel(fileObj: any): string {
+  const fileRef = fileObj?.file;
+  const filename =
+    fileRef && typeof fileRef === "object" && typeof fileRef.description === "string"
+      ? fileRef.description.trim()
+      : "";
+  if (filename) return filename;
+  const summaryDocType = (fileObj?.summary as any)?.documentType;
+  if (typeof summaryDocType === "string" && summaryDocType.trim()) {
+    return summaryDocType.trim();
+  }
+  if (typeof fileObj?.documentType === "string" && fileObj.documentType.trim()) {
+    return fileObj.documentType.trim();
+  }
+  return "Document";
+}
+
 export function makeReadDocumentExecutor(
   allFiles: any[]
 ): (name: string, input: Record<string, unknown>) => Promise<ToolExecutionResult> {
@@ -80,8 +108,7 @@ export function makeReadDocumentExecutor(
       const fileObj = allFiles.find((f: any) => f._id.toString() === fileId);
       if (!fileObj) throw new Error(`File ${fileId} not found`);
 
-      const docLabel =
-        (fileObj.summary as any)?.documentType || fileObj.documentType || "Document";
+      const docLabel = buildFileLabel(fileObj);
       const pageIndex = fileObj.pageIndex as Array<{ page: number; summary: string }> | undefined;
 
       if (!pageIndex || pageIndex.length === 0) {
@@ -110,7 +137,7 @@ export function makeReadDocumentExecutor(
         ? (fileObj.file as any)._id.toString()
         : (fileObj.file as any).toString();
 
-    const docLabel = (fileObj.summary as any)?.documentType || fileObj.documentType || "Document";
+    const docLabel = buildFileLabel(fileObj);
 
     // Deduplicate same document + page range within this turn
     const rangeKey = `${fileId}:${input.start_page ?? 0}:${input.end_page ?? "end"}`;

--- a/server/src/models/Tender/schema/index.ts
+++ b/server/src/models/Tender/schema/index.ts
@@ -48,6 +48,33 @@ export class TenderJobSummaryClass {
 }
 
 @ObjectType()
+export class TenderFileCategoryClass {
+  // Stable ID — survives category renames and prompts. Generated when the
+  // category is first created by the categorizer.
+  @Field(() => ID)
+  public _id!: Types.ObjectId;
+
+  // Human label ("Drawings", "Specifications", "Schedule of Quantities", …).
+  @Field()
+  @prop({ required: true, trim: true })
+  public name!: string;
+
+  // Display order among categories. 0 = first. Claude picks this based on
+  // typical-access-frequency for a tender estimation workflow (drawings
+  // and schedules of quantities tend to rank earlier than addenda).
+  @Field()
+  @prop({ required: true, default: 0 })
+  public order!: number;
+
+  // Denormalized — EnrichedFile IDs that belong to this category. Lets
+  // the UI render "files in folder X" without iterating every tender
+  // file to check ownership.
+  @Field(() => [ID])
+  @prop({ type: () => [Types.ObjectId], required: true, default: [] })
+  public fileIds!: Types.ObjectId[];
+}
+
+@ObjectType()
 export class TenderSchema {
   @Field(() => ID, { nullable: false })
   public _id!: Types.ObjectId;
@@ -83,6 +110,16 @@ export class TenderSchema {
   @Field(() => [TenderNoteClass])
   @prop({ type: () => [TenderNoteClass], default: [] })
   public notes!: TenderNoteClass[];
+
+  // AI-generated document folders. Populated by the categorizer
+  // (lib/categorizeTenderFiles) — a 60s-debounced full re-categorization
+  // that runs after any file in this tender reaches "ready" status.
+  // Files not present in any category's fileIds list are shown as
+  // "Uncategorized" in the UI (covers in-flight uploads and anything
+  // that arrived between categorization passes).
+  @Field(() => [TenderFileCategoryClass], { nullable: true })
+  @prop({ type: () => [TenderFileCategoryClass], default: [] })
+  public fileCategories?: TenderFileCategoryClass[];
 
   @Field(() => TenderJobSummaryClass, { nullable: true })
   @prop({ type: () => TenderJobSummaryClass, required: false })


### PR DESCRIPTION
## Summary

Two commits ahead of production. All scoped to tender document organization — search, auto-categorization, and a read_document label fix for the chat tools.

### feat: tender document organization — search, auto-categorization, filename fix (27576814)

**Search bar**
- Pinned above the scrollable file list. Substring filter across filename, AI-generated documentType, key topics, and the summary overview. Overview is included so a search for "temperature" finds a spec book even when the per-page index isn't loaded. Only rendered when there's more than one file. X icon to clear.

**Auto-categorization into folders**
- New \`server/src/lib/categorizeTenderFiles.ts\`. Single Claude call per pass — takes filename + documentType + overview + keyTopics for every summarized file and asks for a small number (typically 3-7) of construction-appropriate folders, ordered from most-accessed first (drawings, schedules of quantities) to least (addenda, permits, reference specs).
- 60s debounce via \`scheduleCategorization(tenderId)\`. A batch upload of 30 files collapses into a single Claude call.
- Always-full re-categorization: every pass starts fresh. No incremental assignment.
- Handler hook in \`enrichedFileSummaryHandler.ts\` — fires on every \`ready\` transition (not gated on "all files done") so folders appear before the full tender finishes processing.
- Schema: new \`TenderFileCategoryClass\` on the Tender model (\`_id\` / \`name\` / \`order\` / \`fileIds[]\`). Nullable, no migration needed for existing tenders.
- UI: Chakra \`Accordion\` in \`TenderDocuments.tsx\` with all sections open by default. "Uncategorized" bucket at the end for files not claimed by any category. Flat-list fallback when no categories exist yet (first upload before the debounce fires). During search, empty groups are hidden.

**read_document filename fix**
- \`buildFileLabel()\` in \`readDocumentExecutor.ts\` now prefers the real uploaded filename (\`file.description\`) over the AI-generated \`summary.documentType\`. Fixes the confusing "Loaded document: Schedule of Quantities with Letter of Intent" tool log lines. Also corrects the Claude citation hint ("When citing this document use the filename: X") which was showing the AI's document type instead of the actual filename.

### fix(tender): pin search bar above the scrollable file list (d6f45742)

Moves the search bar out of the scrollable container into its own \`flexShrink={0}\` section between the upload area and the file list. Stays visible while scrolling long document lists.

## Test plan

- [ ] Upload several new files to a tender — confirm they start appearing in the flat list, then re-group into AI folders within ~60s
- [ ] Existing tenders with many files — confirm they categorize on next upload
- [ ] Search bar: try filename, documentType, and keyTopic matches; confirm empty groups hide during search
- [ ] Search bar stays visible while scrolling a long document list
- [ ] Chat RAG: ask a question that triggers \`read_document\` and confirm the tool log now shows the actual filename, not the AI documentType
- [ ] Chat RAG: confirm citations reference the filename correctly
- [ ] "Uncategorized" bucket appears when a file is uploaded but the next debounce hasn't fired yet
- [ ] Verify no regression in PDF/docx/xlsx/image summary processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)