### PR TITLE
PDF reading fix, anti-hallucination prompt, publish resilience

### DIFF
--- a/server/src/consumer/handlers/enrichedFileSummaryHandler.ts
+++ b/server/src/consumer/handlers/enrichedFileSummaryHandler.ts
@@ -411,15 +411,67 @@ export const enrichedFileSummaryHandler = {
           }
         );
 
-        console.log(
-          `[EnrichedFileSummary] Synthesizing summary from ${pageIndex.length} page descriptions for file ${fileId}...`
-        );
-        summary = await synthesizeSummaryFromPageIndex(
-          anthropic,
-          pageIndex,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (claimed as any).file?.description ?? null
-        );
+        if (pageIndex.length === 0) {
+          // pdf-lib couldn't parse the page tree (e.g. markup-heavy takeoff
+          // PDFs with non-standard catalog structures). Fall back to sending
+          // the raw PDF to Claude for a single-shot summary — no page index,
+          // but at least we get a usable summary + documentType.
+          console.warn(
+            `[EnrichedFileSummary] Page index empty for ${fileId} — falling back to single-shot PDF summary`
+          );
+          const response = await withRateLimitRetry(
+            () =>
+              anthropic.messages.create({
+                model: "claude-haiku-4-5",
+                max_tokens: 512,
+                messages: [
+                  {
+                    role: "user",
+                    content: [
+                      {
+                        type: "text" as const,
+                        text: SINGLE_SHOT_SUMMARY_PROMPT,
+                      },
+                      {
+                        type: "document" as any,
+                        source: {
+                          type: "base64" as const,
+                          media_type: "application/pdf" as const,
+                          data: buffer.toString("base64"),
+                        },
+                      },
+                    ],
+                  },
+                ],
+              }),
+            "pdf-fallback"
+          );
+          const text =
+            response.content[0]?.type === "text"
+              ? response.content[0].text.trim()
+              : "";
+          const cleaned = text
+            .replace(/^```(?:json)?\s*/i, "")
+            .replace(/\s*```$/, "")
+            .trim();
+          try {
+            summary = JSON.parse(cleaned);
+          } catch {
+            throw new Error(
+              `Claude returned invalid JSON for PDF fallback: ${text.slice(0, 200)}`
+            );
+          }
+        } else {
+          console.log(
+            `[EnrichedFileSummary] Synthesizing summary from ${pageIndex.length} page descriptions for file ${fileId}...`
+          );
+          summary = await synthesizeSummaryFromPageIndex(
+            anthropic,
+            pageIndex,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (claimed as any).file?.description ?? null
+          );
+        }
       }
 
       // ── Terminal state ──────────────────────────────────────────────

--- a/server/src/consumer/handlers/summarizePdf.ts
+++ b/server/src/consumer/handlers/summarizePdf.ts
@@ -209,14 +209,14 @@ export async function generatePageIndex(
   options: GeneratePageIndexOptions = {}
 ): Promise<PageIndexEntry[]> {
   let pdfDoc: PDFDocument;
+  let totalPages: number;
   try {
     pdfDoc = await PDFDocument.load(buffer, { ignoreEncryption: true });
+    totalPages = pdfDoc.getPageCount();
   } catch {
-    console.warn("[generatePageIndex] pdf-lib failed to parse — skipping page index");
+    console.warn("[generatePageIndex] pdf-lib failed to parse page tree — skipping page index");
     return [];
   }
-
-  const totalPages = pdfDoc.getPageCount();
   const resumeFrom = options.resumeFrom ?? [];
   const completedPages = new Set(resumeFrom.map((p) => p.page));
   const index: PageIndexEntry[] = [...resumeFrom];

--- a/server/src/consumer/watchdog.ts
+++ b/server/src/consumer/watchdog.ts
@@ -13,9 +13,11 @@ export const PROCESSING_STUCK_MS = 90 * 60_000; // 90 min
 
 /** Max time a file can be in "pending" since its last publish before the
  *  watchdog republishes it. Checked against `queuedAt` (fallback: `createdAt`
- *  for legacy docs that pre-date the field). Must be comfortably larger than
- *  the worst-case queue-drain time for a large upload batch. */
-export const PENDING_STUCK_MS = 3 * 60 * 60_000; // 3 hr
+ *  for legacy docs that pre-date the field). 30 min is long enough for a
+ *  large batch to drain through the queue (prefetch=2, ~2 min per file) but
+ *  short enough that a silently-dropped publish is recovered within one
+ *  watchdog cycle instead of waiting hours. */
+export const PENDING_STUCK_MS = 30 * 60_000; // 30 min
 
 /** Cooldown before retrying a "failed" or "partial" file. */
 export const FAILED_RETRY_COOLDOWN_MS = 60 * 60_000; // 1 hr

--- a/server/src/graphql/resolvers/jobsite/index.ts
+++ b/server/src/graphql/resolvers/jobsite/index.ts
@@ -392,7 +392,10 @@ export default class JobsiteResolver {
       ? enrichedFile.file._id.toString()
       : enrichedFile.file.toString();
 
-    await publishEnrichedFileCreated(fileObjectId.toString(), fileId);
+    const published = await publishEnrichedFileCreated(fileObjectId.toString(), fileId);
+    if (!published) {
+      throw new Error("Failed to queue file for processing — please try again");
+    }
 
     return Jobsite.getById(id);
   }

--- a/server/src/graphql/resolvers/system/index.ts
+++ b/server/src/graphql/resolvers/system/index.ts
@@ -112,7 +112,10 @@ export default class SystemResolver {
       ? enrichedFile.file._id.toString()
       : enrichedFile.file.toString();
 
-    await publishEnrichedFileCreated(fileObjectId.toString(), fileId);
+    const published = await publishEnrichedFileCreated(fileObjectId.toString(), fileId);
+    if (!published) {
+      throw new Error("Failed to queue file for processing — please try again");
+    }
 
     return System.getSystem();
   }

--- a/server/src/graphql/resolvers/tender/index.ts
+++ b/server/src/graphql/resolvers/tender/index.ts
@@ -121,7 +121,10 @@ export default class TenderResolver {
       ? enrichedFile.file._id.toString()
       : enrichedFile.file.toString();
 
-    await publishEnrichedFileCreated(fileObjectId.toString(), fileId);
+    const published = await publishEnrichedFileCreated(fileObjectId.toString(), fileId);
+    if (!published) {
+      throw new Error("Failed to queue file for processing — please try again");
+    }
 
     return Tender.getById(id);
   }

--- a/server/src/lib/mcpContentAdapter.ts
+++ b/server/src/lib/mcpContentAdapter.ts
@@ -1,0 +1,63 @@
+/**
+ * Adapts MCP tool result content blocks for the Anthropic API.
+ *
+ * The MCP SDK validates tool results against its own schema (text, image,
+ * audio, resource) and rejects Anthropic-specific types like "document".
+ * MCP tool handlers encode PDFs as JSON envelopes inside text blocks
+ * (marked with __mcp_document). This adapter detects those envelopes and
+ * reconstructs native Anthropic document blocks before the content is
+ * passed to streamConversation → Claude.
+ *
+ * Also normalizes plain-string content (spreadsheet branch) into a text
+ * block array.
+ */
+
+export function adaptMcpContent(
+  raw: unknown,
+): Array<Record<string, unknown>> {
+  // Normalize string → text block array
+  const blocks: Array<Record<string, unknown>> =
+    typeof raw === "string"
+      ? [{ type: "text", text: raw }]
+      : Array.isArray(raw)
+        ? (raw as Array<Record<string, unknown>>)
+        : [];
+
+  // Unwrap __mcp_document envelopes → native Anthropic document blocks
+  return blocks.map((block) => {
+    if (block.type !== "text" || typeof block.text !== "string") return block;
+
+    // Quick guard: only attempt JSON parse if the text starts with {
+    const text = (block.text as string).trim();
+    if (!text.startsWith("{")) return block;
+
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed?.__mcp_document && parsed.source) {
+        return {
+          type: "document",
+          source: parsed.source,
+        };
+      }
+    } catch {
+      // Not JSON — return the original text block
+    }
+    return block;
+  });
+}
+
+/**
+ * Derive a short summary from adapted content blocks for logging.
+ */
+export function deriveSummary(
+  blocks: Array<Record<string, unknown>>,
+  toolName: string,
+): string {
+  const firstText = blocks.find(
+    (b) => b.type === "text" && typeof b.text === "string",
+  );
+  const text = (firstText?.text as string) ?? "";
+  return text.length > 200
+    ? text.slice(0, 200) + "…"
+    : text || `${toolName} completed`;
+}

--- a/server/src/mcp/tools/tender.ts
+++ b/server/src/mcp/tools/tender.ts
@@ -937,18 +937,27 @@ export function register(
             ? `Pages ${startIdx + 1}–${endIdx} of ${totalPages} total. Use start_page/end_page to read other sections.`
             : `All ${totalPages} pages.`;
 
+        // The MCP SDK doesn't support Anthropic's "document" content type
+        // in tool results — it validates against text/image/audio/resource
+        // only. We encode the PDF as a JSON envelope inside a text block
+        // that the SDK accepts. The chat router's executeTool adapter
+        // detects the __mcp_document marker and reconstructs the native
+        // Anthropic document block before sending to Claude.
         content = [
           {
             type: "text" as const,
             text: `Document: ${docLabel}\n${pageNote}\nWhen citing this document use the filename: "${docLabel}"`,
           },
           {
-            type: "document" as any,
-            source: {
-              type: "base64" as const,
-              media_type: "application/pdf" as const,
-              data: pdfChunk.toString("base64"),
-            },
+            type: "text" as const,
+            text: JSON.stringify({
+              __mcp_document: true,
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: pdfChunk.toString("base64"),
+              },
+            }),
           },
         ];
 

--- a/server/src/rabbitmq/publisher.ts
+++ b/server/src/rabbitmq/publisher.ts
@@ -9,7 +9,7 @@
  * ensures the consumer always sees the latest state.
  */
 
-import mongoose, { Types } from "mongoose";
+import mongoose from "mongoose";
 import { getChannel, setupTopology, RABBITMQ_CONFIG, ROUTING_KEYS } from ".";
 import type { ActionType } from "./config";
 
@@ -177,7 +177,7 @@ export const publishEnrichedFileCreated = async (
       await db
         .collection("enrichedfiles")
         .updateOne(
-          { _id: new Types.ObjectId(enrichedFileId) },
+          { _id: new mongoose.Types.ObjectId(enrichedFileId) },
           { $set: { queuedAt: new Date() } }
         );
     }

--- a/server/src/rabbitmq/publisher.ts
+++ b/server/src/rabbitmq/publisher.ts
@@ -154,6 +154,9 @@ export interface EnrichedFileSummaryMessage {
   attempt?: number;
 }
 
+const PUBLISH_MAX_RETRIES = 3;
+const PUBLISH_RETRY_DELAY_MS = 1000;
+
 export const publishEnrichedFileCreated = async (
   enrichedFileId: string,
   fileId: string,
@@ -165,44 +168,60 @@ export const publishEnrichedFileCreated = async (
     timestamp: new Date().toISOString(),
     attempt,
   };
-  // Stamp queuedAt BEFORE publishing so the watchdog can distinguish files
-  // legitimately waiting in the queue from files whose message was dropped.
-  // Uses a raw collection write to avoid importing @models (which would
-  // introduce a circular import via post-save hooks). If the publish below
-  // fails, queuedAt still reflects the last attempt; the watchdog retries
-  // once the pending cutoff elapses.
-  try {
-    const db = mongoose.connection.db;
-    if (db) {
-      await db
-        .collection("enrichedfiles")
-        .updateOne(
-          { _id: new mongoose.Types.ObjectId(enrichedFileId) },
-          { $set: { queuedAt: new Date() } }
+
+  // Retry the publish up to PUBLISH_MAX_RETRIES times with backoff.
+  // The lazy RabbitMQ connect (getChannel) can fail on transient DNS or
+  // network errors — a single retry usually succeeds.
+  for (let retry = 0; retry < PUBLISH_MAX_RETRIES; retry++) {
+    try {
+      const channel = await getChannel();
+      await setupTopology();
+      const success = channel.publish(
+        RABBITMQ_CONFIG.exchange.name,
+        ROUTING_KEYS.enrichedFile.created,
+        Buffer.from(JSON.stringify(message)),
+        { persistent: true, contentType: "application/json" }
+      );
+      if (success) {
+        console.log(
+          `[RabbitMQ] Published enriched_file.created: ${enrichedFileId}${retry > 0 ? ` (retry ${retry})` : ""}`
         );
+
+        // Stamp queuedAt AFTER successful publish — not before. If the
+        // stamp were before, a failed publish leaves a fresh queuedAt that
+        // makes the watchdog think the file is legitimately queued when it
+        // actually has no queue message.
+        try {
+          const db = mongoose.connection.db;
+          if (db) {
+            await db
+              .collection("enrichedfiles")
+              .updateOne(
+                { _id: new mongoose.Types.ObjectId(enrichedFileId) },
+                { $set: { queuedAt: new Date() } }
+              );
+          }
+        } catch (stampErr) {
+          console.warn(
+            `[RabbitMQ] Failed to stamp queuedAt on ${enrichedFileId}:`,
+            stampErr
+          );
+        }
+      }
+      return success;
+    } catch (error) {
+      console.error(
+        `[RabbitMQ] Publish attempt ${retry + 1}/${PUBLISH_MAX_RETRIES} failed for enriched_file.created:`,
+        error instanceof Error ? error.message : error
+      );
+      if (retry < PUBLISH_MAX_RETRIES - 1) {
+        await new Promise((r) => setTimeout(r, PUBLISH_RETRY_DELAY_MS * (retry + 1)));
+      }
     }
-  } catch (stampErr) {
-    console.warn(
-      `[RabbitMQ] Failed to stamp queuedAt on ${enrichedFileId}:`,
-      stampErr
-    );
-    // Non-fatal — fall through to publish.
   }
-  try {
-    const channel = await getChannel();
-    await setupTopology();
-    const success = channel.publish(
-      RABBITMQ_CONFIG.exchange.name,
-      ROUTING_KEYS.enrichedFile.created,
-      Buffer.from(JSON.stringify(message)),
-      { persistent: true, contentType: "application/json" }
-    );
-    if (success) {
-      console.log(`[RabbitMQ] Published enriched_file.created: ${enrichedFileId}`);
-    }
-    return success;
-  } catch (error) {
-    console.error(`[RabbitMQ] Failed to publish enriched_file.created:`, error);
-    return false;
-  }
+
+  console.error(
+    `[RabbitMQ] All ${PUBLISH_MAX_RETRIES} publish attempts failed for enriched_file.created: ${enrichedFileId}`
+  );
+  return false;
 };

--- a/server/src/router/chat.ts
+++ b/server/src/router/chat.ts
@@ -5,6 +5,7 @@ import { User } from "@models";
 import { streamConversation } from "../lib/streamConversation";
 import { requireAuth } from "../lib/authMiddleware";
 import { connectMcp } from "../lib/mcpClient";
+import { adaptMcpContent, deriveSummary } from "../lib/mcpContentAdapter";
 import { UserRoles } from "../typescript/user";
 
 const router = Router();
@@ -80,12 +81,11 @@ router.post("/message", requireAuth, async (req, res) => {
       tools: mcpTools,
       executeTool: async (name, input) => {
         const mcpResult = await mcpClient.callTool({ name, arguments: input });
-        const text =
-          (mcpResult.content as Array<{ type: string; text?: string }>)
-            .filter((c) => c.type === "text")
-            .map((c) => c.text ?? "")
-            .join("\n") || "No result";
-        return { content: text, summary: text };
+        const blocks = adaptMcpContent(mcpResult.content);
+        return {
+          content: blocks as any,
+          summary: deriveSummary(blocks, name),
+        };
       },
       logPrefix: "[chat]",
     });

--- a/server/src/router/foreman-jobsite-chat.ts
+++ b/server/src/router/foreman-jobsite-chat.ts
@@ -8,6 +8,7 @@ import { buildFileIndex } from "../lib/buildFileIndex";
 import { UserRoles } from "../typescript/user";
 import { requireAuth } from "../lib/authMiddleware";
 import { connectMcp } from "../lib/mcpClient";
+import { adaptMcpContent, deriveSummary } from "../lib/mcpContentAdapter";
 
 // Foremen get the narrowest possible tool surface: document reading only.
 // The MCP server exposes many other tools (tender pricing, analytics,
@@ -171,17 +172,11 @@ ${decompositionBlock}
           name,
           arguments: input as Record<string, unknown>,
         });
-        const raw = result.content ?? [];
-        const blocks: Array<{ type: string; text?: string }> =
-          typeof raw === "string"
-            ? [{ type: "text", text: raw }]
-            : (raw as Array<{ type: string; text?: string }>);
-        const firstText = blocks.find((b) => b.type === "text")?.text ?? "";
-        const summary =
-          firstText.length > 200
-            ? firstText.slice(0, 200) + "…"
-            : firstText || `${name} completed`;
-        return { content: blocks as any, summary };
+        const blocks = adaptMcpContent(result.content);
+        return {
+          content: blocks as any,
+          summary: deriveSummary(blocks, name),
+        };
       },
       logPrefix: "[foreman-jobsite-chat]",
     });

--- a/server/src/router/pm-jobsite-chat.ts
+++ b/server/src/router/pm-jobsite-chat.ts
@@ -8,6 +8,7 @@ import { buildFileIndex } from "../lib/buildFileIndex";
 import { UserRoles } from "../typescript/user";
 import { requireAuth } from "../lib/authMiddleware";
 import { connectMcp } from "../lib/mcpClient";
+import { adaptMcpContent, deriveSummary } from "../lib/mcpContentAdapter";
 
 const router = Router();
 
@@ -173,17 +174,11 @@ ${decompositionBlock}
           name,
           arguments: input as Record<string, unknown>,
         });
-        const raw = result.content ?? [];
-        const blocks: Array<{ type: string; text?: string }> =
-          typeof raw === "string"
-            ? [{ type: "text", text: raw }]
-            : (raw as Array<{ type: string; text?: string }>);
-        const firstText = blocks.find((b) => b.type === "text")?.text ?? "";
-        const summary =
-          firstText.length > 200
-            ? firstText.slice(0, 200) + "…"
-            : firstText || `${name} completed`;
-        return { content: blocks as any, summary };
+        const blocks = adaptMcpContent(result.content);
+        return {
+          content: blocks as any,
+          summary: deriveSummary(blocks, name),
+        };
       },
       logPrefix: "[pm-jobsite-chat]",
     });

--- a/server/src/router/tender-chat.ts
+++ b/server/src/router/tender-chat.ts
@@ -5,6 +5,7 @@ import { Tender, User, System } from "@models";
 import { isDocument } from "@typegoose/typegoose";
 import { streamConversation, ToolExecutionResult } from "../lib/streamConversation";
 import { connectMcp } from "../lib/mcpClient";
+import { adaptMcpContent, deriveSummary } from "../lib/mcpContentAdapter";
 import { buildFileIndex } from "../lib/buildFileIndex";
 import { requireAuth } from "../lib/authMiddleware";
 import { UserRoles } from "../typescript/user";
@@ -215,22 +216,10 @@ When creating or updating line items on the pricing sheet:
           name,
           arguments: input as Record<string, unknown>,
         });
-        // MCP returns content as either an array of typed blocks or a plain
-        // string (the spreadsheet branch of read_document does the latter).
-        // Normalize to an array of blocks before deriving the summary.
-        const raw = result.content ?? [];
-        const blocks: Array<{ type: string; text?: string }> =
-          typeof raw === "string"
-            ? [{ type: "text", text: raw }]
-            : (raw as Array<{ type: string; text?: string }>);
-        const firstText = blocks.find((b) => b.type === "text")?.text ?? "";
-        const summary =
-          firstText.length > 200
-            ? firstText.slice(0, 200) + "…"
-            : firstText || `${name} completed`;
+        const blocks = adaptMcpContent(result.content);
         return {
           content: blocks as any,
-          summary,
+          summary: deriveSummary(blocks, name),
         };
       },
       logPrefix: "[tender-chat]",

--- a/server/src/router/tender-chat.ts
+++ b/server/src/router/tender-chat.ts
@@ -149,9 +149,16 @@ ${fileIndex || "No tender documents have been processed yet."}${pendingNotice}${
 ${decompositionBlock}
 ## Instructions
 
-**Clarify before assuming.** Construction documents often contain multiple instances of similar things — two crossings, two structures, two phases, two contract items with similar names. If a question could apply to more than one thing, ask which one the user means before loading a document.
+**HARD RULE — cite or disclaim.** Every factual claim you make about this project MUST include a citation to a specific document and page you have actually loaded and read. If you cannot point to a specific page that supports what you are about to say, you MUST say "I was not able to find this in the uploaded documents" instead of stating it as fact. This applies especially to:
+- Where something appears on a drawing ("shown on sheet C-3" — only say this if you loaded and read sheet C-3)
+- What a spec requires ("OPSS 1150 requires..." — only say this if you loaded and read that spec page)
+- Quantities, dimensions, or locations ("the 300mm storm sewer runs along..." — only if you read the page showing it)
 
-**Ask when uncertain.** If you read a document and are not confident it contains the answer, say so explicitly and ask the user if they want you to look in a different document or provide more context. Do not guess or fill gaps with general knowledge.
+Do NOT rely on general construction knowledge to fill gaps. If the documents don't contain the answer, say so. Being wrong is far more costly to an estimator than saying "I don't know — I checked these documents and couldn't find it."
+
+**Self-check before responding.** Before you state where something is located on a drawing or what a spec says, verify: did I actually call read_document and load that specific page? If the answer is no, you are about to hallucinate. Stop, and either load the page first or tell the user you haven't been able to find it.
+
+**Clarify before assuming.** Construction documents often contain multiple instances of similar things — two crossings, two structures, two phases, two contract items with similar names. If a question could apply to more than one thing, ask which one the user means before loading a document.
 
 **Loading documents — two steps.** For documents that have a page index, call list_document_pages first to see the page-by-page breakdown, then call read_document with only the specific pages you need. This is much cheaper and faster than loading large page ranges blindly. Only skip list_document_pages if the document has no page index (the navigation hint will say so).
 
@@ -162,6 +169,8 @@ ${decompositionBlock}
 **Cross-references.** When you read a page that references another drawing, document, or standard (e.g. "see Drawing C-3", "per OPSS 1150"), note it explicitly. If it directly answers the question, follow it automatically. If tangential, mention it so the user can decide whether to pursue it.
 
 **Completeness.** Before giving your final answer, confirm you have addressed all parts of the question. If you found cross-references you have not checked, note what is outstanding so the user can decide.
+
+**When you can't find something.** If you've searched the available documents and can't locate what the user is asking about, say so directly: "I searched [list which documents you checked] and was not able to find [what they asked about]. It may be in a document that hasn't been uploaded, or I may have missed it — would you like me to check specific pages?" This is infinitely more helpful than guessing.
 
 **Saving job notes.** If the user mentions something important that is not in the documents — owner preferences, site context, verbal agreements, known risks — draft a 1-2 sentence note and ask "Should I save that to the job notes?" before calling save_tender_note. Never save without explicit confirmation.
 


### PR DESCRIPTION
## Summary

Critical fix: Claude couldn't read PDFs since the MCP migration — every tender chat interaction was working blind.

**PDF document blocks through MCP** — The MCP SDK doesn't support Anthropic's "document" content type in tool results. Every `read_document` call on a PDF has been failing since the migration. Claude fell back to general construction knowledge → hallucinated answers. Fix: encode PDFs as JSON envelopes in text blocks on the MCP side, then reconstruct as native Anthropic document blocks in the chat router adapter. Shared `mcpContentAdapter.ts` applied to all four chat routers.

**Anti-hallucination prompt** — Hard cite-or-disclaim rule: every factual claim must cite a specific page Claude actually loaded. Self-check instruction: "did I actually call read_document for that page? If not, I'm about to hallucinate — stop." Explicit "I couldn't find it" template when documents don't contain the answer.

**Publish resilience** — `publishEnrichedFileCreated` retries 3x with backoff. `queuedAt` stamped AFTER successful publish (not before). Retry mutations throw a GraphQL error if publish fails. Watchdog pending cutoff reduced from 3 hours to 30 minutes.

**Markup PDF fallback** — pdf-lib crash on markup-heavy PDFs (Bluebeam takeoffs) now falls back to single-shot Claude summary instead of crashing the consumer.

**Publisher Types.ObjectId fix** — `import { Types } from "mongoose"` compiled to undefined, silently breaking the `queuedAt` stamp on every publish.

## Test plan

- [ ] Open tender chat, ask Claude to read a specific page from a PDF → should actually load and cite the content (was broken before)
- [ ] Ask about something NOT in the documents → should say "I searched X and couldn't find it" (not hallucinate)
- [ ] Upload a markup-heavy PDF (Bluebeam takeoff) → should process via fallback path
- [ ] Retry a failed file → should either succeed or show "Failed to queue" error (not silently stuck)
- [ ] Consumer pod healthy, no OOMKill (memory bumped in prior PR)
- [ ] Watchdog marks exhausted files within first scan cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)