### PR TITLE
Deploy: singleSelect controller + inactive group zeroing + recent fixes

### DIFF
--- a/client/src/components/TenderPricing/calculators/evaluate.ts
+++ b/client/src/components/TenderPricing/calculators/evaluate.ts
@@ -94,12 +94,12 @@ export function evaluateTemplate(
   const ctx: Record<string, number> = { quantity };
 
   for (const p of template.parameterDefs) {
-    ctx[p.id] = inputs?.params[p.id] ?? p.defaultValue;
+    ctx[p.id] = inactiveNodeIds?.has(p.id) ? 0 : (inputs?.params[p.id] ?? p.defaultValue);
   }
 
   for (const t of template.tableDefs) {
     const rows = inputs?.tables[t.id] ?? t.defaultRows ?? [];
-    ctx[`${t.id}RatePerHr`] = rows.reduce((s, r) => s + r.qty * r.ratePerHour, 0);
+    ctx[`${t.id}RatePerHr`] = inactiveNodeIds?.has(t.id) ? 0 : rows.reduce((s, r) => s + r.qty * r.ratePerHour, 0);
   }
 
   // Inject controller values (percentage/toggle) — formula steps may reference them by ID
@@ -169,12 +169,12 @@ export function debugEvaluateTemplate(
   const ctx: Record<string, number> = { quantity };
 
   for (const p of template.parameterDefs) {
-    ctx[p.id] = inputs?.params[p.id] ?? p.defaultValue;
+    ctx[p.id] = inactiveNodeIds?.has(p.id) ? 0 : (inputs?.params[p.id] ?? p.defaultValue);
   }
 
   for (const t of template.tableDefs) {
     const rows = inputs?.tables[t.id] ?? t.defaultRows ?? [];
-    ctx[`${t.id}RatePerHr`] = rows.reduce((s, r) => s + r.qty * r.ratePerHour, 0);
+    ctx[`${t.id}RatePerHr`] = inactiveNodeIds?.has(t.id) ? 0 : rows.reduce((s, r) => s + r.qty * r.ratePerHour, 0);
   }
 
   // Inject controller values (percentage/toggle) — formula steps may reference them by ID

--- a/client/src/components/pages/developer/CalculatorCanvas/CanvasFlow.tsx
+++ b/client/src/components/pages/developer/CalculatorCanvas/CanvasFlow.tsx
@@ -221,7 +221,7 @@ interface ContextMenuProps {
   onCopy: (ids: string[]) => void;
   onPaste: (position: { x: number; y: number }) => void;
   onDelete: (ids: string[]) => void;
-  onCreate: (type: "formula" | "param" | "table" | "breakdown" | "output" | "group" | "controller:percentage" | "controller:toggle" | "controller:selector", pos: { x: number; y: number }) => void;
+  onCreate: (type: "formula" | "param" | "table" | "breakdown" | "output" | "group" | "controller:percentage" | "controller:toggle" | "controller:selector" | "controller:singleSelect", pos: { x: number; y: number }) => void;
   onDismiss: () => void;
 }
 
@@ -278,7 +278,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
             boxShadow: "0 8px 30px rgba(0,0,0,0.6)",
             zIndex: 1001,
           }}>
-            {(["percentage", "toggle", "selector"] as const).map((ctrlType) => (
+            {(["percentage", "toggle", "selector", "singleSelect"] as const).map((ctrlType) => (
               <div
                 key={ctrlType}
                 style={MENU_ITEM}
@@ -290,7 +290,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
                 onMouseEnter={(e) => (e.currentTarget.style.background = "#334155")}
                 onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
               >
-                {ctrlType === "percentage" ? "Percentage" : ctrlType === "toggle" ? "Toggle" : "Selector"}
+                {ctrlType === "percentage" ? "Percentage" : ctrlType === "toggle" ? "Toggle" : ctrlType === "singleSelect" ? "Single Select" : "Selector"}
               </div>
             ))}
           </div>
@@ -407,7 +407,7 @@ interface Props {
   onCopy: (nodeIds: string[]) => void;
   onPaste: (position: { x: number; y: number }) => void;
   onDeleteNodes: (nodeIds: string[]) => void;
-  onCreateNode: (type: "formula" | "param" | "table" | "breakdown" | "output" | "group" | "controller:percentage" | "controller:toggle" | "controller:selector", position: { x: number; y: number }) => void;
+  onCreateNode: (type: "formula" | "param" | "table" | "breakdown" | "output" | "group" | "controller:percentage" | "controller:toggle" | "controller:selector" | "controller:singleSelect", position: { x: number; y: number }) => void;
   positionResetKey: number;
 }
 

--- a/client/src/components/pages/developer/CalculatorCanvas/InspectPanel.tsx
+++ b/client/src/components/pages/developer/CalculatorCanvas/InspectPanel.tsx
@@ -805,8 +805,8 @@ const ControllerEdit: React.FC<{
         </Box>
       )}
 
-      {/* Selector options */}
-      {ctrl.type === "selector" && (
+      {/* Selector / singleSelect options */}
+      {(ctrl.type === "selector" || ctrl.type === "singleSelect") && (
         <Box mb={3}>
           <Text fontSize="10px" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wide" mb={2}>
             Options
@@ -887,14 +887,15 @@ const ControllerEdit: React.FC<{
                 return (
                   <Flex key={opt.id} align="center" gap={2} mb={1} cursor="pointer"
                     onClick={() => {
+                      const isSingle = ctrl.type === "singleSelect";
                       const newSelected = isSelected
                         ? (ctrl.defaultSelected ?? []).filter((id) => id !== opt.id)
-                        : [...(ctrl.defaultSelected ?? []), opt.id];
+                        : isSingle ? [opt.id] : [...(ctrl.defaultSelected ?? []), opt.id];
                       updateCtrl({ defaultSelected: newSelected });
                     }}
                   >
                     <Box w={3} h={3} border="1px solid" borderColor={isSelected ? "teal.400" : "gray.300"}
-                      bg={isSelected ? "teal.400" : "transparent"} rounded="sm" />
+                      bg={isSelected ? "teal.400" : "transparent"} rounded={ctrl.type === "singleSelect" ? "full" : "sm"} />
                     <Text fontSize="xs" color="gray.600">{opt.label}</Text>
                   </Flex>
                 );
@@ -984,8 +985,8 @@ const GroupEdit: React.FC<{
         </Box>
       )}
 
-      {/* Option selector for selector type */}
-      {ctrl && ctrl.type === "selector" && (
+      {/* Option selector for selector / singleSelect type */}
+      {ctrl && (ctrl.type === "selector" || ctrl.type === "singleSelect") && (
         <Box mb={3}>
           <Text fontSize="10px" color="gray.400" mb={1}>Active when option</Text>
           <Select

--- a/client/src/components/pages/developer/CalculatorCanvas/LiveTestPanel.tsx
+++ b/client/src/components/pages/developer/CalculatorCanvas/LiveTestPanel.tsx
@@ -63,7 +63,7 @@ function initControllers(
       c.id,
       seed[c.id] !== undefined
         ? seed[c.id]
-        : c.type === "selector"
+        : c.type === "selector" || c.type === "singleSelect"
         ? (c.defaultSelected ?? [])
         : c.type === "toggle"
         ? (c.defaultValue as boolean ?? false)

--- a/client/src/components/pages/developer/CalculatorCanvas/RateBuildupInputs.tsx
+++ b/client/src/components/pages/developer/CalculatorCanvas/RateBuildupInputs.tsx
@@ -279,8 +279,9 @@ const ControllerWidget: React.FC<{
     );
   }
 
-  // selector — pill options
+  // selector / singleSelect — pill options
   const selected = value as string[];
+  const isSingle = ctrl.type === "singleSelect";
   return (
     <Box mb={3}>
       <Text fontSize="xs" fontWeight="semibold" color="gray.500" textTransform="uppercase" letterSpacing="wide" mb={1.5}>
@@ -307,8 +308,12 @@ const ControllerWidget: React.FC<{
               transition="all 0.1s ease"
               _hover={{ borderColor: isSelected ? "orange.400" : "gray.300", color: isSelected ? "orange.700" : "gray.600" }}
               onClick={() => {
-                const next = isSelected ? selected.filter((id) => id !== opt.id) : [...selected, opt.id];
-                onChange(ctrl.id, next);
+                if (isSingle) {
+                  onChange(ctrl.id, isSelected ? [] : [opt.id]);
+                } else {
+                  const next = isSelected ? selected.filter((id) => id !== opt.id) : [...selected, opt.id];
+                  onChange(ctrl.id, next);
+                }
               }}
             >
               {opt.label}
@@ -469,7 +474,7 @@ const GroupSection: React.FC<GroupSectionProps> = ({
             const ctrl = (doc.controllerDefs ?? []).find((c) => c.id === id)!;
             return (
               <ControllerWidget key={id} ctrl={ctrl}
-                value={controllers[id] ?? (ctrl.type === "selector" ? [] : ctrl.type === "toggle" ? false : 0)}
+                value={controllers[id] ?? (ctrl.type === "selector" || ctrl.type === "singleSelect" ? [] : ctrl.type === "toggle" ? false : 0)}
                 onChange={onControllerChange} />
             );
           })}
@@ -499,7 +504,7 @@ const GroupSection: React.FC<GroupSectionProps> = ({
             <Box key={ctrl.id} mb={2}>
               {ctrl.type !== "toggle" && (
                 <ControllerWidget ctrl={ctrl}
-                  value={controllers[ctrl.id] ?? (ctrl.type === "selector" ? [] : 0)}
+                  value={controllers[ctrl.id] ?? (ctrl.type === "selector" || ctrl.type === "singleSelect" ? [] : 0)}
                   onChange={onControllerChange} />
               )}
               {groupIds.map((id) => {
@@ -1022,7 +1027,7 @@ const RateBuildupInputs: React.FC<RateBuildupInputsProps> = ({
         <Box mb={4}>
           {loneControllers.map((c) => (
             <ControllerWidget key={c.id} ctrl={c}
-              value={controllers[c.id] ?? (c.type === "selector" ? [] : c.type === "toggle" ? false : 0)}
+              value={controllers[c.id] ?? (c.type === "selector" || c.type === "singleSelect" ? [] : c.type === "toggle" ? false : 0)}
               onChange={onControllerChange} />
           ))}
         </Box>
@@ -1053,7 +1058,7 @@ const RateBuildupInputs: React.FC<RateBuildupInputsProps> = ({
         <Box key={ctrl.id} mb={3}>
           {ctrl.type !== "toggle" && (
             <ControllerWidget ctrl={ctrl}
-              value={controllers[ctrl.id] ?? (ctrl.type === "selector" ? [] : 0)}
+              value={controllers[ctrl.id] ?? (ctrl.type === "selector" || ctrl.type === "singleSelect" ? [] : 0)}
               onChange={onControllerChange} />
           )}
           {groups.map((g) => (

--- a/client/src/components/pages/developer/CalculatorCanvas/canvasOps.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/canvasOps.ts
@@ -530,7 +530,7 @@ export function createGroup(
 export function createController(
   doc: CanvasDocument,
   position: { x: number; y: number },
-  type: "percentage" | "toggle" | "selector" = "percentage"
+  type: "percentage" | "toggle" | "selector" | "singleSelect" = "percentage"
 ): { doc: CanvasDocument; newId: string } {
   const takenIds = new Set([
     ...doc.controllerDefs.map((c) => c.id),
@@ -544,7 +544,7 @@ export function createController(
     "quantity", "unitPrice",
   ]);
   const takenLabels = new Set(doc.controllerDefs.map((c) => c.label));
-  const baseLabel = type === "percentage" ? "Percentage" : type === "toggle" ? "Toggle" : "Selector";
+  const baseLabel = type === "percentage" ? "Percentage" : type === "toggle" ? "Toggle" : type === "singleSelect" ? "Single Select" : "Selector";
   const label = nextLabel(baseLabel, takenLabels);
   const id = nextSlugId(`${slugify(label)}_${type}`, takenIds);
 
@@ -555,7 +555,7 @@ export function createController(
     position: { x: position.x, y: position.y },
     ...(type === "percentage" ? { defaultValue: 0.5 } : {}),
     ...(type === "toggle" ? { defaultValue: false } : {}),
-    ...(type === "selector" ? { options: [], defaultSelected: [] } : {}),
+    ...(type === "selector" || type === "singleSelect" ? { options: [], defaultSelected: [] } : {}),
   };
 
   return {

--- a/client/src/components/pages/developer/CalculatorCanvas/canvasTypes.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/canvasTypes.ts
@@ -42,12 +42,12 @@ export interface UnitVariant {
 export interface ControllerDef {
   id: string;
   label: string;
-  type: "percentage" | "toggle" | "selector";
+  type: "percentage" | "toggle" | "selector" | "singleSelect";
   /** Percentage: 0–1 number. Toggle: boolean. Absent for selector. */
   defaultValue?: number | boolean;
-  /** Selector only */
+  /** Selector / singleSelect only */
   options?: ControllerOption[];
-  /** Selector only: option IDs selected by default */
+  /** Selector / singleSelect only: option IDs selected by default */
   defaultSelected?: string[];
   hint?: string;      // template-level guidance shown read-only to estimators
   position: Position; // canvas node position

--- a/client/src/components/pages/developer/CalculatorCanvas/edgeParser.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/edgeParser.ts
@@ -22,7 +22,7 @@ export function parseEdges(template: CalculatorTemplate | CanvasDocument): Edge[
     ...template.tableDefs.map((t) => `${t.id}RatePerHr`),
     ...template.formulaSteps.map((s) => s.id),
     // Percentage and Toggle controllers can be referenced in formula expressions
-    ...controllerDefs.filter((c) => c.type !== "selector").map((c) => c.id),
+    ...controllerDefs.filter((c) => c.type !== "selector" && c.type !== "singleSelect").map((c) => c.id),
   ]);
 
   // Formula steps: parse each formula string for variable name tokens.
@@ -80,7 +80,7 @@ export function parseEdges(template: CalculatorTemplate | CanvasDocument): Edge[
     if (!group.activation) continue;
     const ctrl = controllerDefs.find((c) => c.id === group.activation!.controllerId);
     const sourceHandle =
-      ctrl?.type === "selector" && group.activation.optionId
+      (ctrl?.type === "selector" || ctrl?.type === "singleSelect") && group.activation.optionId
         ? group.activation.optionId
         : undefined;
     edges.push({

--- a/client/src/components/pages/developer/CalculatorCanvas/index.tsx
+++ b/client/src/components/pages/developer/CalculatorCanvas/index.tsx
@@ -198,7 +198,7 @@ const CalculatorCanvas: React.FC<Props> = ({
     for (const c of (doc.controllerDefs ?? [])) {
       if (c.type === "percentage") result[c.id] = typeof c.defaultValue === "number" ? c.defaultValue : 0;
       else if (c.type === "toggle") result[c.id] = c.defaultValue ?? false;
-      else if (c.type === "selector") result[c.id] = c.defaultSelected ?? [];
+      else if (c.type === "selector" || c.type === "singleSelect") result[c.id] = c.defaultSelected ?? [];
     }
     return result;
   }, [doc]);
@@ -267,14 +267,14 @@ const CalculatorCanvas: React.FC<Props> = ({
   }, [doc, handleSave, selectedNodeId]);
 
   const handleCreateNode = useCallback(
-    (type: "formula" | "param" | "table" | "breakdown" | "output" | "group" | "controller:percentage" | "controller:toggle" | "controller:selector", position: { x: number; y: number }) => {
+    (type: "formula" | "param" | "table" | "breakdown" | "output" | "group" | "controller:percentage" | "controller:toggle" | "controller:selector" | "controller:singleSelect", position: { x: number; y: number }) => {
       if (type === "group") {
         const { doc: newDoc, newId } = createGroup(doc, position);
         handleSave(newDoc);
         setSelectedNodeId(newId);
         setPositionResetKey((k) => k + 1);
       } else if (type.startsWith("controller:")) {
-        const ctrlType = type.split(":")[1] as "percentage" | "toggle" | "selector";
+        const ctrlType = type.split(":")[1] as "percentage" | "toggle" | "selector" | "singleSelect";
         const { doc: newDoc, newId } = createController(doc, position, ctrlType);
         handleSave(newDoc);
         setSelectedNodeId(newId);

--- a/client/src/components/pages/developer/CalculatorCanvas/nodeTypes.tsx
+++ b/client/src/components/pages/developer/CalculatorCanvas/nodeTypes.tsx
@@ -126,7 +126,7 @@ export const QuantityNode: React.FC<NodeProps> = ({ data, selected }) => (
 );
 
 export const ControllerNode: React.FC<NodeProps> = ({ data, selected }) => {
-  const isSelector = data.controllerType === "selector";
+  const isSelector = data.controllerType === "selector" || data.controllerType === "singleSelect";
   const isToggle = data.controllerType === "toggle";
 
   return (
@@ -173,7 +173,9 @@ export const ControllerNode: React.FC<NodeProps> = ({ data, selected }) => {
                   fontFamily: "monospace",
                   lineHeight: "1.6",
                 }}>
-                  {isSelected ? "☑" : "☐"} {opt.label}
+                  {data.controllerType === "singleSelect"
+                    ? (isSelected ? "●" : "○")
+                    : (isSelected ? "☑" : "☐")} {opt.label}
                 </div>
                 <Handle
                   type="source"

--- a/client/src/components/pages/developer/CalculatorCanvas/snapshotEvaluator.ts
+++ b/client/src/components/pages/developer/CalculatorCanvas/snapshotEvaluator.ts
@@ -29,7 +29,7 @@ export function isGroupActive(
   const ctrl = doc.controllerDefs.find((c) => c.id === activation.controllerId);
   if (!ctrl) return true; // controller deleted — treat as always active
 
-  if (ctrl.type === "selector") {
+  if (ctrl.type === "selector" || ctrl.type === "singleSelect") {
     const selected = (controllers[activation.controllerId] as string[] | undefined)
       ?? ctrl.defaultSelected ?? [];
     // If optionId is not yet set (in-progress authoring), treat as inactive
@@ -175,7 +175,7 @@ export function snapshotFromTemplate(template: CanvasDocument): RateBuildupSnaps
       controllers[c.id] = typeof c.defaultValue === "number" ? c.defaultValue : 0;
     else if (c.type === "toggle")
       controllers[c.id] = typeof c.defaultValue === "boolean" ? c.defaultValue : false;
-    else if (c.type === "selector")
+    else if (c.type === "selector" || c.type === "singleSelect")
       controllers[c.id] = c.defaultSelected ?? [];
   }
 
@@ -306,8 +306,8 @@ export function evaluateCanvasDoc(
     } else if (c.type === "toggle") {
       controllerNumeric[c.id] = c.defaultValue ? 1 : 0;
     }
-    // selector controllers aren't numeric — skip. Their activation is
-    // evaluated separately via isGroupActive.
+    // selector/singleSelect controllers aren't numeric — skip. Their
+    // activation is evaluated separately via isGroupActive.
   }
 
   // 3. Which nodes are inactive (inside groups whose activation evaluates

--- a/client/src/constants/units.ts
+++ b/client/src/constants/units.ts
@@ -24,6 +24,7 @@ export const CANONICAL_UNITS: CanonicalUnit[] = [
   { code: "day",    label: "day",    name: "Days",           dimension: "time"   },
   { code: "ea",     label: "EA",     name: "Each",           dimension: null     },
   { code: "ls",     label: "LS",     name: "Lump Sum",       dimension: null     },
+  { code: "ca",     label: "CA",     name: "Cash Allowance", dimension: null     },
 ];
 
 export const CANONICAL_UNIT_CODES = new Set(CANONICAL_UNITS.map((u) => u.code));

--- a/server/src/constants/units.ts
+++ b/server/src/constants/units.ts
@@ -24,6 +24,7 @@ export const CANONICAL_UNITS: CanonicalUnit[] = [
   { code: "day",    label: "day",    name: "Days",           dimension: "time"   },
   { code: "ea",     label: "EA",     name: "Each",           dimension: null     },
   { code: "ls",     label: "LS",     name: "Lump Sum",       dimension: null     },
+  { code: "ca",     label: "CA",     name: "Cash Allowance", dimension: null     },
 ] as const;
 
 export const CANONICAL_UNIT_CODES = new Set(CANONICAL_UNITS.map((u) => u.code));

--- a/server/src/mcp/tools/tender.ts
+++ b/server/src/mcp/tools/tender.ts
@@ -5,7 +5,10 @@ import mongoose from "mongoose";
 import { Tender as TenderModel, Jobsite, EnrichedFile, System, TenderPricingSheet } from "@models";
 import { UserRoles } from "@typescript/user";
 import { TenderPricingRowType } from "@typescript/tenderPricingSheet";
+import { CANONICAL_UNITS, resolveUnitCode } from "@constants/units";
 import { scheduleTenderSummary } from "../../lib/generateTenderSummary";
+
+const UNIT_CODES_DESCRIPTION = `Unit code. Must be one of the canonical codes: ${CANONICAL_UNITS.map((u) => `${u.code} (${u.name})`).join(", ")}. The system may also have custom units — use the codes exactly as shown in get_tender_pricing_rows output.`;
 import { getRequestContext, requireTenderContext } from "../context";
 import Anthropic from "@anthropic-ai/sdk";
 import { PDFDocument } from "pdf-lib";
@@ -297,7 +300,7 @@ export function register(
               description: z.string().min(1),
               indentLevel: z.number().int().min(0).max(3).default(0),
               quantity: z.number().optional(),
-              unit: z.string().optional(),
+              unit: z.string().optional().describe(UNIT_CODES_DESCRIPTION),
               notes: z.string().optional(),
               docRefs: z
                 .array(
@@ -373,7 +376,7 @@ export function register(
           description: r.description,
           indentLevel: r.indentLevel,
           ...(r.type === TenderPricingRowType.Item && r.quantity != null ? { quantity: r.quantity } : {}),
-          ...(r.type === TenderPricingRowType.Item && r.unit != null ? { unit: r.unit } : {}),
+          ...(r.type === TenderPricingRowType.Item && r.unit != null ? { unit: resolveUnitCode(r.unit) } : {}),
           ...(r.notes != null ? { notes: r.notes } : {}),
           docRefs: (r.docRefs ?? []).map((d) => ({
             _id: new mongoose.Types.ObjectId(),
@@ -414,7 +417,7 @@ export function register(
               description: z.string().optional(),
               indentLevel: z.number().int().min(0).max(3).optional(),
               quantity: z.number().optional(),
-              unit: z.string().optional(),
+              unit: z.string().optional().describe(UNIT_CODES_DESCRIPTION),
               unitPrice: z.number().nullable().optional(),
               appendNotes: z.string().optional(),
               replaceNotes: z
@@ -529,7 +532,7 @@ export function register(
           fieldsChanged.push("quantity");
         }
         if (u.unit !== undefined) {
-          row.unit = u.unit;
+          row.unit = resolveUnitCode(u.unit);
           fieldsChanged.push("unit");
         }
         if (u.unitPrice !== undefined) {

--- a/server/src/models/RateBuildupTemplate/schema/index.ts
+++ b/server/src/models/RateBuildupTemplate/schema/index.ts
@@ -39,7 +39,7 @@ export class RateBuildupControllerOption {
 export class RateBuildupControllerDef {
   @Field() @prop({ required: true }) public id!: string;
   @Field() @prop({ required: true }) public label!: string;
-  /** "percentage" | "toggle" | "selector" */
+  /** "percentage" | "toggle" | "selector" | "singleSelect" */
   @Field() @prop({ required: true }) public type!: string;
   /** Percentage: 0–1. Toggle: 0 or 1. Absent for selector. */
   @Field(() => Float, { nullable: true }) @prop() public defaultValue?: number;

--- a/server/src/router/tender-chat.ts
+++ b/server/src/router/tender-chat.ts
@@ -185,9 +185,15 @@ When creating or updating line items on the pricing sheet:
 
 **Work in batches.** Never create more than 25–50 rows in a single call. After each batch, call get_tender_pricing_rows to verify the results are correct before continuing with the next batch. If the schedule of quantities has 100+ items, tell the user you'll work through it in sections.
 
-**Spec references are the priority.** Every line item should have a specification reference (docRef) if one exists in the uploaded documents. Look for the spec first — drawing references are supplementary (nice-to-have, not required). If you can find the spec but not a drawing, add the spec. If you can find a drawing but not the spec, add the drawing AND add a note: "Spec reference not found in uploaded documents."
+**Three-tier referencing.** For every line item, attempt to find BOTH a specification reference and a drawing location. Your note must reflect which tier the item falls into:
 
-**Be confident or explicit.** Only add a docRef or note when you are confident it is correct. If you cannot find a specification or drawing for a line item, do not guess — instead add a note stating what you looked for and could not find (e.g. "No spec found for granular base course — checked OPSS index, not listed"). Never leave a line item silently without references.
+1. **Found both** — add the spec docRef + drawing docRef. Note includes the spec section and where it appears on the drawing (sheet number, label/callout text you read).
+2. **Found spec only** — add the spec docRef. Note: "Spec: [section]. Drawing location: NOT FOUND — searched sheets [list which you checked]. Manual review needed."
+3. **Found neither** — no docRefs. Note: "NEEDS REVIEW — no spec or drawing reference found. Searched: [list documents/pages checked]."
+
+Spec references come from text-searchable spec books — you CAN reliably find these by reading tables of contents and section headings. Drawing locations are harder: you can only find items that are LABELED on drawings (callout tags, legend entries, title block references, detail labels). You CANNOT trace unlabeled lines, measure pipe runs, or identify items that are only represented visually without a text label. When a drawing doesn't have a clear label for an item, say so — do not guess based on what typically appears on construction drawings.
+
+**Confidence rule.** Only add a docRef when you have loaded the page AND can see the item referenced on it. Never add a speculative docRef. A note saying "NOT FOUND" with which documents you searched is far more useful to the estimator than a wrong reference they'll waste time chasing.
 
 **Self-correct.** After creating rows and verifying with get_tender_pricing_rows, review your own work. If you added an incorrect note or doc reference, use replaceNotes to fix the note or removeDocRefIds to remove the bad reference. Do not leave incorrect references in place.`;
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -14,6 +14,7 @@ import { Company, System } from "@models";
 import mongoose from "mongoose";
 import createApp from "./app";
 import { bindEventEmitters } from "@events";
+import { setupTopology } from "./rabbitmq";
 
 let workerEnabled = true,
   apiEnabled = true;
@@ -40,6 +41,16 @@ const main = async () => {
 
     // Bind Event Emitters
     bindEventEmitters();
+
+    // Eagerly connect to RabbitMQ so the first file upload/retry doesn't
+    // have to wait for the lazy connection. If RabbitMQ isn't available
+    // yet, the publisher's retry logic (3 attempts with backoff) handles
+    // it per-call — this just warms the connection for the common case.
+    if (process.env.NODE_ENV !== "test") {
+      setupTopology().catch((err) =>
+        console.warn("[RabbitMQ] Eager connect failed (will retry lazily):", err.message)
+      );
+    }
 
     // Start API server
     if (apiEnabled) {


### PR DESCRIPTION
## Summary
- **singleSelect controller type** for rate buildup templates — radio behavior (one option at a time)
- **Inactive group zeroing** now applies to params and tables, not just formula steps
- Plus all recent master commits since last deploy (MCP fixes, tender chat improvements, PDF handling, etc.)

## Test plan
- [x] Canvas tests pass (93 tests)
- [x] Evaluator tests pass (25 tests)
- [x] TypeScript compiles clean (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)